### PR TITLE
Square api updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Test Coverage](https://api.codeclimate.com/v1/badges/7b6c53096c35381463c5/test_coverage)](https://codeclimate.com/github/NikolaGavric94/laravel-square/test_coverage)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/4b0db75125acf7f4bdfb/test_coverage)](https://codeclimate.com/github/Mrkbingham/laravel-square/test_coverage)
 [![Build and test PHP 8.x](https://github.com/NikolaGavric94/laravel-square/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/NikolaGavric94/laravel-square/actions/workflows/main.yml)
 [![Latest Stable Version](https://poser.pugx.org/nikolag/laravel-square/v/stable)](https://packagist.org/packages/nikolag/laravel-square) 
 [![License](https://poser.pugx.org/nikolag/laravel-square/license)](https://packagist.org/packages/nikolag/laravel-square)

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "square/square": "29.0.0.20230720"
     },
     "require-dev": {
-        "barryvdh/laravel-ide-helper": "^3.0",
         "fakerphp/faker": "^1.13",
         "laravel/legacy-factories": "^1.3",
         "orchestra/testbench": "8.x",

--- a/composer.json
+++ b/composer.json
@@ -29,10 +29,11 @@
         "square/square": "29.0.0.20230720"
     },
     "require-dev": {
+        "barryvdh/laravel-ide-helper": "^3.0",
         "fakerphp/faker": "^1.13",
+        "laravel/legacy-factories": "^1.3",
         "orchestra/testbench": "8.x",
-        "phpunit/phpunit": "10.x",
-        "laravel/legacy-factories": "^1.3"
+        "phpunit/phpunit": "10.x"
     },
     "autoload": {
         "psr-4": {

--- a/src/SquareConfig.php
+++ b/src/SquareConfig.php
@@ -70,6 +70,9 @@ class SquareConfig extends CoreConfig
     /**
      * Api for transactions.
      *
+     * @deprecated cf. https://developer.squareup.com/docs/build-basics/api-lifecycle#deprecated
+     * @see https://developer.squareup.com/docs/payments-api/migrate-from-transactions-api
+     *
      * @return TransactionsApi
      */
     public function transactionsAPI(): TransactionsApi

--- a/src/SquareConfig.php
+++ b/src/SquareConfig.php
@@ -5,6 +5,7 @@ namespace Nikolag\Square;
 use Nikolag\Core\CoreConfig;
 use Nikolag\Core\Exceptions\InvalidConfigurationException;
 use Square\Apis\CustomersApi;
+use Square\Apis\CatalogApi;
 use Square\Apis\LocationsApi;
 use Square\Apis\OrdersApi;
 use Square\Apis\PaymentsApi;
@@ -44,6 +45,16 @@ class SquareConfig extends CoreConfig
     public function locationsAPI(): LocationsApi
     {
         return $this->squareClient->getLocationsApi();
+    }
+
+    /**
+     * Api for catalog.
+     *
+     * @return CatalogApi
+     */
+    public function catalogAPI(): CatalogApi
+    {
+        return $this->squareClient->getCatalogApi();
     }
 
     /**

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -24,11 +24,14 @@ use Square\Models\BatchUpsertCatalogObjectsResponse;
 use Square\Models\CreateCustomerRequest;
 use Square\Models\CreateOrderRequest;
 use Square\Models\Error;
+use Square\Models\CreateCatalogImageRequest;
+use Square\Models\CreateCatalogImageResponse;
 use Square\Models\ListCatalogResponse;
 use Square\Models\ListLocationsResponse;
 use Square\Models\RetrieveLocationResponse;
 use Square\Models\ListPaymentsResponse;
 use Square\Models\UpdateCustomerRequest;
+use Square\Utils\FileWrapper;
 use stdClass;
 
 class SquareService extends CorePaymentService implements SquareServiceContract
@@ -120,6 +123,40 @@ class SquareService extends CorePaymentService implements SquareServiceContract
 
         if ($apiResponse->isSuccess()) {
             /** @var BatchUpsertCatalogObjectsResponse $results */
+            $results = $apiResponse->getResult();
+
+            return $results;
+        } else {
+            throw $this->_handleApiResponseErrors($apiResponse);
+        }
+    }
+
+    /**
+     * Creates a catalog image.
+     *
+     * @param CreateCatalogImageRequest $createCatalogImageRequest The request to create the image.
+     * @param string                    $filePath                  The image to upload.
+     *
+     * @throws Exception When an error occurs.
+     *
+     * @return CreateCatalogImageResponse
+     */
+    public function createCatalogImage(
+        CreateCatalogImageRequest $createCatalogImageRequest,
+        string $filePath
+    ) {
+        // Check to see if the file exists
+        if (!file_exists($filePath)) {
+            throw new Exception('The file does not exist');
+        }
+        // Create a file wrapper
+        $fileWrapper = FileWrapper::createFromPath($filePath);
+
+        // Call the Catalog API function createCatalogImage to upload the image
+        $apiResponse = $this->config->catalogAPI()->createCatalogImage($createCatalogImageRequest, $fileWrapper);
+
+        if ($apiResponse->isSuccess()) {
+            /** @var CreateCatalogImageResponse $results */
             $results = $apiResponse->getResult();
 
             return $results;

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -65,6 +65,10 @@ class SquareService extends CorePaymentService implements SquareServiceContract
      */
     private RecipientBuilder $recipientBuilder;
     /**
+     * @var SquareConfig
+     */
+    private string $config;
+    /**
      * @var string
      */
     private string $locationId;
@@ -104,7 +108,6 @@ class SquareService extends CorePaymentService implements SquareServiceContract
         $this->fulfillmentBuilder = new FulfillmentBuilder();
         $this->recipientBuilder = new RecipientBuilder();
     }
-
 
     /**
      * Uploads the items, and adds images, when creating new items for the catalog.
@@ -193,11 +196,13 @@ class SquareService extends CorePaymentService implements SquareServiceContract
      * List locations.
      *
      * @return ListLocationsResponse
-     *
-     * @throws ApiException
      */
     public function locations(): ListLocationsResponse
     {
+        $response = $this->config->locationsAPI()->listLocations()->getResult();
+        if (is_array($response)) {
+            dd($response);
+        }
         return $this->config->locationsAPI()->listLocations()->getResult();
     }
 

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -23,6 +23,7 @@ use Square\Models\CreateCustomerRequest;
 use Square\Models\CreateOrderRequest;
 use Square\Models\Error;
 use Square\Models\ListLocationsResponse;
+use Square\Models\RetrieveLocationResponse;
 use Square\Models\ListPaymentsResponse;
 use Square\Models\UpdateCustomerRequest;
 use stdClass;
@@ -108,6 +109,20 @@ class SquareService extends CorePaymentService implements SquareServiceContract
     public function locations(): ListLocationsResponse
     {
         return $this->config->locationsAPI()->listLocations()->getResult();
+    }
+
+    /**
+     * Retrieves a specific location.
+     *
+     * @param string $locationId The location ID.
+     *
+     * @return RetrieveLocationResponse
+     *
+     * @throws ApiException
+     */
+    public function retrieveLocation(string $locationId): RetrieveLocationResponse
+    {
+        return $this->config->locationsAPI()->retrieveLocation($locationId)->getResult();
     }
 
     /**

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -101,6 +101,20 @@ class SquareService extends CorePaymentService implements SquareServiceContract
     }
 
     /**
+     * Helper function to get the appropriate currency to be used based on the location ID provided.
+     *
+     * @param string|null $locationId The location ID.
+     *
+     *
+     * @return string The currency code
+     */
+    public function getCurrency($locationId = 'main')
+    {
+        // Get the currency for the location
+        return $this->retrieveLocation($locationId)->getLocation()->getCurrency();
+    }
+
+    /**
      * Retrieves the Square API request builder.
      *
      * @return SquareRequestBuilder

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -65,10 +65,6 @@ class SquareService extends CorePaymentService implements SquareServiceContract
      */
     private RecipientBuilder $recipientBuilder;
     /**
-     * @var SquareConfig
-     */
-    private string $config;
-    /**
      * @var string
      */
     private string $locationId;

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -199,10 +199,6 @@ class SquareService extends CorePaymentService implements SquareServiceContract
      */
     public function locations(): ListLocationsResponse
     {
-        $response = $this->config->locationsAPI()->listLocations()->getResult();
-        if (is_array($response)) {
-            dd($response);
-        }
         return $this->config->locationsAPI()->listLocations()->getResult();
     }
 

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -101,6 +101,16 @@ class SquareService extends CorePaymentService implements SquareServiceContract
     }
 
     /**
+     * Retrieves the Square API request builder.
+     *
+     * @return SquareRequestBuilder
+     */
+    public function getSquareBuilder(): SquareRequestBuilder
+    {
+        return $this->squareBuilder;
+    }
+
+    /**
      * List locations.
      *
      * @return ListLocationsResponse

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -19,6 +19,8 @@ use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
 use Square\Exceptions\ApiException;
 use Square\Http\ApiResponse;
+use Square\Models\BatchUpsertCatalogObjectsRequest;
+use Square\Models\BatchUpsertCatalogObjectsResponse;
 use Square\Models\CreateCustomerRequest;
 use Square\Models\CreateOrderRequest;
 use Square\Models\Error;
@@ -98,6 +100,32 @@ class SquareService extends CorePaymentService implements SquareServiceContract
         $this->customerBuilder = new CustomerBuilder();
         $this->fulfillmentBuilder = new FulfillmentBuilder();
         $this->recipientBuilder = new RecipientBuilder();
+    }
+
+
+    /**
+     * Uploads the items, and adds images, when creating new items for the catalog.
+     *
+     * @param BatchUpsertCatalogObjectsRequest $batchUpsertCatalogRequest The request to upload the items.
+     *
+     * @throws Exception When an error occurs.
+     *
+     * @return BatchUpsertCatalogObjectsResponse
+     */
+    public function batchUpsertCatalog(BatchUpsertCatalogObjectsRequest $batchUpsertCatalogRequest)
+    {
+        // We call the Catalog API function batchUpsertCatalogObjects to upload all our
+        // items at once.
+        $apiResponse = $this->config->catalogAPI()->batchUpsertCatalogObjects($batchUpsertCatalogRequest);
+
+        if ($apiResponse->isSuccess()) {
+            /** @var BatchUpsertCatalogObjectsResponse $results */
+            $results = $apiResponse->getResult();
+
+            return $results;
+        } else {
+            throw $this->_handleApiResponseErrors($apiResponse);
+        }
     }
 
     /**

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -22,6 +22,7 @@ use Square\Http\ApiResponse;
 use Square\Models\CreateCustomerRequest;
 use Square\Models\CreateOrderRequest;
 use Square\Models\Error;
+use Square\Models\ListCatalogResponse;
 use Square\Models\ListLocationsResponse;
 use Square\Models\RetrieveLocationResponse;
 use Square\Models\ListPaymentsResponse;
@@ -123,6 +124,18 @@ class SquareService extends CorePaymentService implements SquareServiceContract
     public function retrieveLocation(string $locationId): RetrieveLocationResponse
     {
         return $this->config->locationsAPI()->retrieveLocation($locationId)->getResult();
+    }
+
+    /**
+     * Lists the entire catalog.
+     *
+     * @return ListCatalogResponse
+     *
+     * @throws ApiException
+     */
+    public function listCatalog(): ListCatalogResponse
+    {
+        return $this->config->catalogApi()->listCatalog()->getResult();
     }
 
     /**

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -14,6 +14,9 @@ use Nikolag\Square\Utils\Util;
 use Square\Models\CreateCustomerRequest;
 use Square\Models\CreateOrderRequest;
 use Square\Models\CreatePaymentRequest;
+use Square\Models\CatalogObject;
+use Square\Models\CatalogObjectType;
+use Square\Models\CreateCatalogImageRequest;
 use Square\Models\Fulfillment;
 use Square\Models\FulfillmentPickupDetails;
 use Square\Models\FulfillmentPickupDetailsCurbsidePickupDetails;
@@ -28,6 +31,14 @@ use Square\Models\OrderLineItemAppliedTax;
 use Square\Models\OrderLineItemDiscount;
 use Square\Models\OrderLineItemTax;
 use Square\Models\UpdateCustomerRequest;
+use Square\Models\Builders\CatalogCategoryBuilder;
+use Square\Models\Builders\CatalogImageBuilder;
+use Square\Models\Builders\CatalogItemBuilder;
+use Square\Models\Builders\CatalogItemVariationBuilder;
+use Square\Models\Builders\CatalogObjectBuilder;
+use Square\Models\Builders\CatalogTaxBuilder;
+use Square\Models\Builders\CreateCatalogImageRequestBuilder;
+use Square\Models\Builders\MoneyBuilder;
 
 class SquareRequestBuilder
 {

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -31,6 +31,8 @@ use Square\Models\OrderLineItemAppliedDiscount;
 use Square\Models\OrderLineItemAppliedTax;
 use Square\Models\OrderLineItemDiscount;
 use Square\Models\OrderLineItemTax;
+use Square\Models\TaxCalculationPhase;
+use Square\Models\TaxInclusionType;
 use Square\Models\UpdateCustomerRequest;
 use Square\Models\Builders\CatalogCategoryBuilder;
 use Square\Models\Builders\CatalogImageBuilder;
@@ -134,6 +136,46 @@ class SquareRequestBuilder
         )
             ->presentAtAllLocations($allLocations)
             ->itemData($catalogItemBuilder->build())
+            ->build();
+    }
+
+    /**
+     * Builds a tax catalog object item.
+     *
+     * @param string  $name                   The name of the tax.
+     * @param string  $percentage             The percentage of the tax.
+     * @param string  $calculationPhase       The calculation phase of the tax.
+     * @param string  $inclusionType          The inclusion type of the tax.
+     * @param boolean $appliesToCustomAmounts Whether the tax applies to custom amounts.
+     * @param boolean $enabled                Whether the tax is enabled.
+     * @param boolean $allLocations           Whether the tax is present at all locations.
+     *
+     * @return CatalogObject
+     */
+    public function buildTaxCatalogObject(
+        string $name,
+        string $percentage,
+        string $calculationPhase = TaxCalculationPhase::TAX_TOTAL_PHASE,
+        string $inclusionType = TaxInclusionType::ADDITIVE,
+        bool $appliesToCustomAmounts = true,
+        bool $enabled = true,
+        bool $allLocations = true
+    ): CatalogObject {
+        return CatalogObjectBuilder::init(
+            CatalogObjectType::TAX,
+            '#' . $name
+        )
+            ->presentAtAllLocations($allLocations)
+            ->taxData(
+                CatalogTaxBuilder::init()
+                    ->name($name)
+                    ->calculationPhase($calculationPhase)
+                    ->inclusionType($inclusionType)
+                    ->percentage($percentage)
+                    ->appliesToCustomAmounts($appliesToCustomAmounts)
+                    ->enabled($enabled)
+                    ->build()
+            )
             ->build();
     }
 

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -13,6 +13,7 @@ use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
 use Square\Models\CreateCustomerRequest;
 use Square\Models\CreateOrderRequest;
+use Square\Models\CatalogPricingType;
 use Square\Models\CreatePaymentRequest;
 use Square\Models\CatalogObject;
 use Square\Models\CatalogObjectType;
@@ -88,6 +89,51 @@ class SquareRequestBuilder
                     ->name($name)
                     ->build()
             )
+            ->build();
+    }
+
+    /**
+     * Builds an item catalog object item.
+     *
+     * @param string               $name         The name of the item.
+     * @param array                $taxIDs       The tax IDs of the item.
+     * @param string               $description  The description of the item.
+     * @param array<CatalogObject> $variations   The variations of the item.
+     * @param string               $categoryID   The category of the item.
+     * @param boolean              $allLocations Whether the item is present at all locations.
+     *
+     * @return CatalogObject
+     */
+    public function buildItemCatalogObject(
+        string $name,
+        array $taxIDs,
+        string $description,
+        array $variations,
+        string $categoryID,
+        bool $allLocations = true
+    ): CatalogObject {
+        // Create a catalog item builder
+        $catalogItemBuilder = CatalogItemBuilder::init()
+            ->name($name)
+            ->taxIds($taxIDs)
+            ->variations($variations)
+            ->categoryId($categoryID);
+
+        // Add the description to the catalog item builder
+        if (!empty($description)) {
+            if ($description != strip_tags($description)) {
+                $catalogItemBuilder->descriptionHtml($description);
+            } else {
+                $catalogItemBuilder->description($description);
+            }
+        }
+
+        return CatalogObjectBuilder::init(
+            CatalogObjectType::ITEM,
+            '#' . $name
+        )
+            ->presentAtAllLocations($allLocations)
+            ->itemData($catalogItemBuilder->build())
             ->build();
     }
 

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -92,6 +92,25 @@ class SquareRequestBuilder
     }
 
     /**
+     * Builds a money object.
+     *
+     * @param integer $amount   The amount of the money.
+     * @param string  $currency The currency of the money.
+     *
+     * @return Money
+     */
+    public function buildMoney(
+        int $amount,
+        string $currency
+    ): Money {
+        return MoneyBuilder::init()
+            ->amount($amount)
+            ->currency($currency)
+            ->build();
+    }
+
+
+    /**
      * Adds curb side pickup details to the pickup details.
      *
      * @param  PickupDetails  $fulfillmentDetails

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Nikolag\Square\Builders;
 
+use Str;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Nikolag\Square\Exceptions\InvalidSquareOrderException;
@@ -233,6 +234,42 @@ class SquareRequestBuilder
             ->build();
     }
 
+    /**
+     * Uploads an image file to be represented by a CatalogImage object that can be linked to an existing CatalogObject
+     * instance. The resulting CatalogImage is unattached to any CatalogObject if the object_id is not specified.
+     *
+     * This CreateCatalogImage endpoint accepts HTTP multipart/form-data requests with a JSON part and an image file
+     * part in JPEG, PJPEG, PNG, or GIF format. The maximum file size is 15MB.
+     *
+     * @param string $catalogObjectId The ID of the object to which the image is attached.
+     * @param string $caption         The caption of the image.
+     * @param bool   $isPrimary       Whether the image is the primary image.
+     *
+     * @return CreateCatalogImageRequest
+     */
+    public function buildCatalogImageRequest(
+        string $catalogObjectId,
+        string $caption = '',
+        bool $isPrimary = true
+    ): CreateCatalogImageRequest {
+        $builder =  CreateCatalogImageRequestBuilder::init(
+            (string) Str::uuid(), // Generate an idempotencyKey
+            CatalogObjectBuilder::init(
+                CatalogObjectType::IMAGE,
+                '#TEMP_ID'
+            )
+                ->imageData(
+                    CatalogImageBuilder::init()
+                        ->caption($caption)
+                        ->build()
+                )
+                ->build()
+        )
+        ->isPrimary($isPrimary)
+        ->objectId($catalogObjectId);
+
+        return $builder->build();
+    }
 
     /**
      * Adds curb side pickup details to the pickup details.

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -231,7 +231,7 @@ class SquareRequestBuilder
     public function buildVariationCatalogObject(array $data): CatalogObject
     {
         // Get the required fields
-        $this->validateRequiredFields($data, ['name', 'variation_id', 'item_id', 'price_money', 'pricing_type']);
+        $this->validateRequiredFields($data, ['name', 'variation_id', 'item_id', 'price_money']);
         $name        = $data['name'];
         $variationID = $data['variation_id'];
         $itemID      = $data['item_id'];

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -69,19 +69,41 @@ class SquareRequestBuilder
     }
 
     /**
+     * Validates that the required fields are present in the data array.
+     *
+     * @param array $data
+     * @param array $requiredFields
+     *
+     * @throws MissingPropertyException
+     *
+     * @return void
+     */
+    public function validateRequiredFields(array $data, array $requiredFields): void
+    {
+        foreach ($requiredFields as $field) {
+            if (!array_key_exists($field, $data) || empty($data[$field])) {
+                throw new MissingPropertyException("The $field field is required", 500);
+            }
+        }
+    }
+
+    /**
      * Builds a category catalog object item.
      *
-     * @param string  $id           The ID of the category.
-     * @param string  $name         The name of the category.
-     * @param boolean $allLocations Whether the category is present at all locations.
+     * @param array $data
      *
      * @return CatalogObject
      */
-    public function buildCategoryCatalogObject(
-        string $id,
-        string $name,
-        bool $allLocations = true
-    ): CatalogObject {
+    public function buildCategoryCatalogObject(array $data): CatalogObject
+    {
+        // Get the required fields
+        $this->validateRequiredFields($data, ['id', 'name']);
+        $id   = $data['id'];
+        $name = $data['name'];
+
+        // Get the optional fields
+        $allLocations = $data['all_locations'] ?? true;
+
         return CatalogObjectBuilder::init(
             CatalogObjectType::CATEGORY,
             $id
@@ -98,23 +120,23 @@ class SquareRequestBuilder
     /**
      * Builds an item catalog object item.
      *
-     * @param string               $name         The name of the item.
-     * @param array                $taxIDs       The tax IDs of the item.
-     * @param string               $description  The description of the item.
-     * @param array<CatalogObject> $variations   The variations of the item.
-     * @param string               $categoryID   The category of the item.
-     * @param boolean              $allLocations Whether the item is present at all locations.
+     * @param array $data
      *
      * @return CatalogObject
      */
-    public function buildItemCatalogObject(
-        string $name,
-        array $taxIDs,
-        string $description,
-        array $variations,
-        string $categoryID,
-        bool $allLocations = true
-    ): CatalogObject {
+    public function buildItemCatalogObject(array $data): CatalogObject
+    {
+        // Get the required fields
+        $this->validateRequiredFields($data, ['name', 'tax_ids', 'description', 'variations', 'category_id']);
+        $name        = $data['name'];
+        $taxIDs      = $data['tax_ids'];
+        $description = $data['description'];
+        $variations  = $data['variations'];
+        $categoryID  = $data['category_id'];
+
+        // Get the optional fields
+        $allLocations = $data['all_locations'] ?? true;
+
         // Create a catalog item builder
         $catalogItemBuilder = CatalogItemBuilder::init()
             ->name($name)
@@ -143,25 +165,24 @@ class SquareRequestBuilder
     /**
      * Builds a tax catalog object item.
      *
-     * @param string  $name                   The name of the tax.
-     * @param string  $percentage             The percentage of the tax.
-     * @param string  $calculationPhase       The calculation phase of the tax.
-     * @param string  $inclusionType          The inclusion type of the tax.
-     * @param boolean $appliesToCustomAmounts Whether the tax applies to custom amounts.
-     * @param boolean $enabled                Whether the tax is enabled.
-     * @param boolean $allLocations           Whether the tax is present at all locations.
+     * @param array $data
      *
      * @return CatalogObject
      */
-    public function buildTaxCatalogObject(
-        string $name,
-        string $percentage,
-        string $calculationPhase = TaxCalculationPhase::TAX_TOTAL_PHASE,
-        string $inclusionType = TaxInclusionType::ADDITIVE,
-        bool $appliesToCustomAmounts = true,
-        bool $enabled = true,
-        bool $allLocations = true
-    ): CatalogObject {
+    public function buildTaxCatalogObject(array $data): CatalogObject
+    {
+        // Get the required fields
+        $this->validateRequiredFields($data, ['name', 'percentage']);
+        $name       = $data['name'];
+        $percentage = $data['percentage'];
+
+        // Get the optional fields
+        $calculationPhase       = $data['calculation_phase'] ?? TaxCalculationPhase::TAX_TOTAL_PHASE;
+        $inclusionType          = $data['inclusion_type'] ?? TaxInclusionType::ADDITIVE;
+        $appliesToCustomAmounts = $data['applies_to_custom_amounts'] ?? true;
+        $enabled                = $data['enabled'] ?? true;
+        $allLocations           = $data['all_locations'] ?? true;
+
         return CatalogObjectBuilder::init(
             CatalogObjectType::TAX,
             '#' . $name
@@ -183,15 +204,17 @@ class SquareRequestBuilder
     /**
      * Builds a money object.
      *
-     * @param integer $amount   The amount of the money.
-     * @param string  $currency The currency of the money.
+     * @param array $data
      *
      * @return Money
      */
-    public function buildMoney(
-        int $amount,
-        string $currency
-    ): Money {
+    public function buildMoney(array $data): Money
+    {
+        // Get the required fields
+        $this->validateRequiredFields($data, ['amount', 'currency']);
+        $amount   = $data['amount'];
+        $currency = $data['currency'];
+
         return MoneyBuilder::init()
             ->amount($amount)
             ->currency($currency)
@@ -201,23 +224,26 @@ class SquareRequestBuilder
     /**
      * Builds a variation catalog object item.
      *
-     * @param string  $name         The name of the variation.
-     * @param string  $variationID  The variation ID of the variation.
-     * @param string  $itemID       The item ID of the item for which the variation is being built.
-     * @param Money   $priceMoney   The price money of the variation.
-     * @param string  $pricingType  The pricing type of the variation.
-     * @param boolean $allLocations Whether the variation is present at all locations.
+     * @param array $data
      *
      * @return CatalogObject
      */
-    public function buildVariationCatalogObject(
-        string $name,
-        string $variationID,
-        string $itemID,
-        Money $priceMoney,
-        string $pricingType = CatalogPricingType::FIXED_PRICING,
-        bool $allLocations = true
-    ): CatalogObject {
+    public function buildVariationCatalogObject(array $data): CatalogObject
+    {
+        // Get the required fields
+        $this->validateRequiredFields($data, ['name', 'variation_id', 'item_id', 'price_money', 'pricing_type']);
+        $name        = $data['name'];
+        $variationID = $data['variation_id'];
+        $itemID      = $data['item_id'];
+        $priceMoney  = $data['price_money'];
+        if (!$priceMoney instanceof Money) {
+            throw new MissingPropertyException('The price_money field must be an instance of Money', 500);
+        }
+
+        // Get the optional fields
+        $pricingType  = $data['pricing_type'] ?? CatalogPricingType::FIXED_PRICING;
+        $allLocations = $data['all_locations'] ?? true;
+
         return CatalogObjectBuilder::init(
             CatalogObjectType::ITEM_VARIATION,
             $variationID
@@ -241,17 +267,21 @@ class SquareRequestBuilder
      * This CreateCatalogImage endpoint accepts HTTP multipart/form-data requests with a JSON part and an image file
      * part in JPEG, PJPEG, PNG, or GIF format. The maximum file size is 15MB.
      *
-     * @param string $catalogObjectId The ID of the object to which the image is attached.
-     * @param string $caption         The caption of the image.
-     * @param bool   $isPrimary       Whether the image is the primary image.
+     * @param array $data
      *
      * @return CreateCatalogImageRequest
      */
-    public function buildCatalogImageRequest(
-        string $catalogObjectId,
-        string $caption = '',
-        bool $isPrimary = true
-    ): CreateCatalogImageRequest {
+    public function buildCatalogImageRequest(array $data): CreateCatalogImageRequest
+    {
+        // Get the required fields
+        $this->validateRequiredFields($data, ['catalog_object_id' ]);
+        $catalogObjectId = $data['catalog_object_id'];
+
+        // Get the optional fields
+        $caption   = $data['caption'] ?? null;
+        $isPrimary = $data['is_primary'] ?? true;
+
+        // Create the catalog image request builder
         $builder =  CreateCatalogImageRequestBuilder::init(
             (string) Str::uuid(), // Generate an idempotencyKey
             CatalogObjectBuilder::init(

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -109,6 +109,42 @@ class SquareRequestBuilder
             ->build();
     }
 
+    /**
+     * Builds a variation catalog object item.
+     *
+     * @param string  $name         The name of the variation.
+     * @param string  $variationID  The variation ID of the variation.
+     * @param string  $itemID       The item ID of the item for which the variation is being built.
+     * @param Money   $priceMoney   The price money of the variation.
+     * @param string  $pricingType  The pricing type of the variation.
+     * @param boolean $allLocations Whether the variation is present at all locations.
+     *
+     * @return CatalogObject
+     */
+    public function buildVariationCatalogObject(
+        string $name,
+        string $variationID,
+        string $itemID,
+        Money $priceMoney,
+        string $pricingType = CatalogPricingType::FIXED_PRICING,
+        bool $allLocations = true
+    ): CatalogObject {
+        return CatalogObjectBuilder::init(
+            CatalogObjectType::ITEM_VARIATION,
+            $variationID
+        )
+            ->presentAtAllLocations($allLocations)
+            ->itemVariationData(
+                CatalogItemVariationBuilder::init()
+                    ->itemId($itemID)
+                    ->name($name)
+                    ->pricingType($pricingType)
+                    ->priceMoney($priceMoney)
+                    ->build()
+            )
+            ->build();
+    }
+
 
     /**
      * Adds curb side pickup details to the pickup details.

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -54,6 +54,33 @@ class SquareRequestBuilder
     }
 
     /**
+     * Builds a category catalog object item.
+     *
+     * @param string  $id           The ID of the category.
+     * @param string  $name         The name of the category.
+     * @param boolean $allLocations Whether the category is present at all locations.
+     *
+     * @return CatalogObject
+     */
+    public function buildCategoryCatalogObject(
+        string $id,
+        string $name,
+        bool $allLocations = true
+    ): CatalogObject {
+        return CatalogObjectBuilder::init(
+            CatalogObjectType::CATEGORY,
+            $id
+        )
+            ->presentAtAllLocations($allLocations)
+            ->categoryData(
+                CatalogCategoryBuilder::init()
+                    ->name($name)
+                    ->build()
+            )
+            ->build();
+    }
+
+    /**
      * Adds curb side pickup details to the pickup details.
      *
      * @param  PickupDetails  $fulfillmentDetails

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -7,6 +7,8 @@ use Nikolag\Square\Contracts\SquareServiceContract;
 use Nikolag\Square\Builders\SquareRequestBuilder;
 use Nikolag\Square\Models\Transaction;
 use Nikolag\Square\SquareService;
+use Square\Models\CreateCatalogImageRequest;
+use Square\Models\CreateCatalogImageResponse;
 use Square\Models\BatchUpsertCatalogObjectsResponse;
 use Square\Models\ListLocationsResponse;
 use Square\Models\ListPaymentsResponse;
@@ -15,6 +17,7 @@ use Square\Models\RetrieveLocationResponse;
 /**
  * @method static SquareService save()
  * @method static string getCurrency()
+ * @method static CreateCatalogImageResponse createCatalogImage(CreateCatalogImageRequest $createCatalogImageRequest, string $filePath)
  * @method static BatchUpsertCatalogObjectsResponse batchUpsertCatalog(BatchUpsertCatalogObjectsRequest $batchUpsertCatalogRequest)
  * @method static ListLocationsResponse locations()
  * @method static RetrieveLocationResponse retrieveLocation(string $locationId)

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -7,6 +7,7 @@ use Nikolag\Square\Contracts\SquareServiceContract;
 use Nikolag\Square\Builders\SquareRequestBuilder;
 use Nikolag\Square\Models\Transaction;
 use Nikolag\Square\SquareService;
+use Square\Models\BatchUpsertCatalogObjectsResponse;
 use Square\Models\ListLocationsResponse;
 use Square\Models\ListPaymentsResponse;
 use Square\Models\RetrieveLocationResponse;
@@ -14,6 +15,7 @@ use Square\Models\RetrieveLocationResponse;
 /**
  * @method static SquareService save()
  * @method static string getCurrency()
+ * @method static BatchUpsertCatalogObjectsResponse batchUpsertCatalog(BatchUpsertCatalogObjectsRequest $batchUpsertCatalogRequest)
  * @method static ListLocationsResponse locations()
  * @method static RetrieveLocationResponse retrieveLocation(string $locationId)
  * @method static SquareRequestBuilder getSquareBuilder()

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -4,15 +4,18 @@ namespace Nikolag\Square\Facades;
 
 use Illuminate\Support\Facades\Facade;
 use Nikolag\Square\Contracts\SquareServiceContract;
+use Nikolag\Square\Builders\SquareRequestBuilder;
 use Nikolag\Square\Models\Transaction;
 use Nikolag\Square\SquareService;
+use Square\Models\ListLocationsResponse;
 use Square\Models\ListPaymentsResponse;
+use Square\Models\RetrieveLocationResponse;
 
 /**
  * @method static SquareService save()
- * @method static SquareService locations()
- * @method static SquareService retrieveLocation(string $locationId)
- * @method static SquareService getSquareBuilder()
+ * @method static ListLocationsResponse locations()
+ * @method static RetrieveLocationResponse retrieveLocation(string $locationId)
+ * @method static SquareRequestBuilder getSquareBuilder()
  * @method static SquareService listCatalog()
  * @method static Transaction charge(array $data)
  * @method static ListPaymentsResponse payments(array $options)

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -12,7 +12,7 @@ use Square\Models\ListPaymentsResponse;
  * @method static SquareService save()
  * @method static SquareService locations()
  * @method static SquareService retrieveLocation(string $locationId)
- * @method static SquareService getBuilder()
+ * @method static SquareService getSquareBuilder()
  * @method static SquareService listCatalog()
  * @method static Transaction charge(array $data)
  * @method static ListPaymentsResponse payments(array $options)

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -10,6 +10,9 @@ use Square\Models\ListPaymentsResponse;
 
 /**
  * @method static SquareService save()
+ * @method static SquareService locations()
+ * @method static SquareService retrieveLocation(string $locationId)
+ * @method static SquareService listCatalog()
  * @method static Transaction charge(array $data)
  * @method static ListPaymentsResponse payments(array $options)
  * @method static mixed getCustomer()

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -12,6 +12,7 @@ use Square\Models\ListPaymentsResponse;
  * @method static SquareService save()
  * @method static SquareService locations()
  * @method static SquareService retrieveLocation(string $locationId)
+ * @method static SquareService getBuilder()
  * @method static SquareService listCatalog()
  * @method static Transaction charge(array $data)
  * @method static ListPaymentsResponse payments(array $options)

--- a/src/facades/Square.php
+++ b/src/facades/Square.php
@@ -13,6 +13,7 @@ use Square\Models\RetrieveLocationResponse;
 
 /**
  * @method static SquareService save()
+ * @method static string getCurrency()
  * @method static ListLocationsResponse locations()
  * @method static RetrieveLocationResponse retrieveLocation(string $locationId)
  * @method static SquareRequestBuilder getSquareBuilder()

--- a/src/providers/SquareServiceProvider.php
+++ b/src/providers/SquareServiceProvider.php
@@ -45,9 +45,5 @@ class SquareServiceProvider extends ServiceProvider
 
         //Facades
         $this->app->alias(SquareService::class, 'square');
-
-        if ($this->app->isLocal()) {
-            $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
-        }
     }
 }

--- a/src/providers/SquareServiceProvider.php
+++ b/src/providers/SquareServiceProvider.php
@@ -45,5 +45,9 @@ class SquareServiceProvider extends ServiceProvider
 
         //Facades
         $this->app->alias(SquareService::class, 'square');
+
+        if ($this->app->isLocal()) {
+            $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
+        }
     }
 }

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -76,6 +76,19 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Tests the getCurrency method.
+     *
+     * @return void
+     */
+    public function test_get_currency(): void
+    {
+        $currency = Square::getCurrency();
+
+        $this->assertNotNull($currency);
+        $this->assertEquals('USD', $currency);
+    }
+
+    /**
      * Returns the square request builder.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -58,13 +58,43 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Tests the buildVariationCatalogObject method.
+     *
+     * @return void
+     */
+    public function test_build_variation_catalog_object(): void
+    {
+        // Set up the variables
+        $id     = 'Variation #1';
+        $name   = 'Test Item Description';
+        $itemID = 'Item #1';
+        $money  = Square::getSquareBuilder()->buildMoney(1000, Square::getCurrency());
+
+        // Build the item object
+        $item = Square::getSquareBuilder()->buildVariationCatalogObject(
+            $name,
+            $id,
+            $itemID,
+            $money
+        );
+
+        $this->assertNotNull($item);
+        $this->assertInstanceOf(\Square\Models\CatalogObject::class, $item);
+        $this->assertEquals('ITEM_VARIATION', $item->getType());
+        $this->assertEquals($id, $item->getId());
+        $this->assertEquals($name, $item->getItemVariationData()->getName());
+        $this->assertEquals($itemID, $item->getItemVariationData()->getItemId());
+        $this->assertEquals($money, $item->getItemVariationData()->getPriceMoney());
+    }
+
+    /**
      * Tests the buildMoney method.
      *
      * @return void
      */
     public function test_build_money(): void
     {
-        $amount = 1000;
+        $amount   = 1000;
         $currency = 'USD';
 
         $money = Square::getSquareBuilder()->buildMoney($amount, $currency);

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -58,6 +58,53 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Tests the buildItemCatalogObject method.
+     *
+     * @return void
+     */
+    public function test_build_item_catalog_object(): void
+    {
+        // Set up the variables
+        $name        = 'Test Item Name';
+        $taxIDs      = [1, 2, 3];
+        $description = 'Test Item Description';
+        $money       = Square::getSquareBuilder()->buildMoney(1000, Square::getCurrency());
+
+        // First, create the default variation and category objects
+        $variation = Square::getSquareBuilder()->buildVariationCatalogObject(
+            'Variation Name',
+            'Variation #1',
+            'Item ID',
+            $money
+        );
+        $category = Square::getSquareBuilder()->buildCategoryCatalogObject(
+            1,
+            'Category Name'
+        );
+
+        // Build the item object
+        $item = Square::getSquareBuilder()->buildItemCatalogObject(
+            $name,
+            $taxIDs,
+            $description,
+            [$variation],
+            $category->getId()
+        );
+
+        $this->assertNotNull($item);
+        $this->assertInstanceOf(\Square\Models\CatalogObject::class, $item);
+        $this->assertEquals('ITEM', $item->getType());
+        // Make sure the ID is the name with a preceding "#" character
+        $this->assertEquals('#' . $name, $item->getId());
+        $this->assertEquals($name, $item->getItemData()->getName());
+        $this->assertEquals($taxIDs, $item->getItemData()->getTaxIds());
+        $this->assertEquals($description, $item->getItemData()->getDescription());
+        $this->assertEquals($variation, $item->getItemData()->getVariations()[0]);
+        $this->assertEquals($category->getId(), $item->getItemData()->getCategoryId());
+
+    }
+
+    /**
      * Tests the buildVariationCatalogObject method.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -34,6 +34,19 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Returns the square request builder.
+     *
+     * @return void
+     */
+    public function test_get_square_builder(): void
+    {
+        $builder = Square::getSquareBuilder();
+
+        $this->assertNotNull($builder);
+        $this->assertInstanceOf('\Nikolag\Square\Builders\SquareRequestBuilder', $builder);
+    }
+
+    /**
      * Charge OK.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -491,6 +491,19 @@ class SquareServiceTest extends TestCase
      *
      * @return void
      */
+    public function test_square_list_catalog(): void
+    {
+        $catalog = Square::listCatalog();
+
+        $this->assertNotNull($catalog);
+        $this->assertInstanceOf('\Square\Models\ListCatalogResponse', $catalog);
+    }
+
+    /**
+     * Tests retrieving a specific location.
+     *
+     * @return void
+     */
     public function test_square_retrieve_location(): void
     {
         $transactions = Square::retrieveLocation('main');

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -34,6 +34,20 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Tests the buildCategoryCatalogObject method.
+     *
+     * @return void
+     */
+    public function test_build_category_catalog_object(): void
+    {
+        $category = Square::getSquareBuilder()->buildCategoryCatalogObject('Test Category');
+
+        $this->assertNotNull($category);
+        $this->assertInstanceOf(CatalogObject::class, $category);
+        $this->assertEquals('Test Category', $category->getCategoryData()->getName());
+    }
+
+    /**
      * Returns the square request builder.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -40,11 +40,21 @@ class SquareServiceTest extends TestCase
      */
     public function test_build_category_catalog_object(): void
     {
-        $category = Square::getSquareBuilder()->buildCategoryCatalogObject('Test Category');
+        // Set up the variables
+        $id   = 1;
+        $name = 'Test Category Description';
+
+        // Build the category object
+        $category = Square::getSquareBuilder()->buildCategoryCatalogObject(
+            $id,
+            $name
+        );
 
         $this->assertNotNull($category);
-        $this->assertInstanceOf(CatalogObject::class, $category);
-        $this->assertEquals('Test Category', $category->getCategoryData()->getName());
+        $this->assertInstanceOf(\Square\Models\CatalogObject::class, $category);
+        $this->assertEquals('CATEGORY', $category->getType());
+        $this->assertEquals($id, $category->getId());
+        $this->assertEquals($name, $category->getCategoryData()->getName());
     }
 
     /**

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -70,10 +70,10 @@ class SquareServiceTest extends TestCase
         $caption         = 'Test Caption';
 
         // Build the image request
-        $imageRequest = Square::getSquareBuilder()->buildCatalogImageRequest(
-            $catalogObjectID,
-            $caption
-        );
+        $imageRequest = Square::getSquareBuilder()->buildCatalogImageRequest([
+            'catalog_object_id' => $catalogObjectID,
+            'caption'           => $caption
+        ]);
 
         $this->assertNotNull($imageRequest);
         $this->assertInstanceOf(\Square\Models\CreateCatalogImageRequest::class, $imageRequest);
@@ -97,10 +97,10 @@ class SquareServiceTest extends TestCase
         $name = 'Test Category Description';
 
         // Build the category object
-        $category = Square::getSquareBuilder()->buildCategoryCatalogObject(
-            $id,
-            $name
-        );
+        $category = Square::getSquareBuilder()->buildCategoryCatalogObject([
+            'id'   => $id,
+            'name' => $name
+        ]);
 
         $this->assertNotNull($category);
         $this->assertInstanceOf(\Square\Models\CatalogObject::class, $category);
@@ -120,28 +120,31 @@ class SquareServiceTest extends TestCase
         $name        = 'Test Item Name';
         $taxIDs      = [1, 2, 3];
         $description = 'Test Item Description';
-        $money       = Square::getSquareBuilder()->buildMoney(1000, Square::getCurrency());
+        $money       = Square::getSquareBuilder()->buildMoney([
+            'amount'   => 1000,
+            'currency' => Square::getCurrency()
+        ]);
 
         // First, create the default variation and category objects
-        $variation = Square::getSquareBuilder()->buildVariationCatalogObject(
-            'Variation Name',
-            'Variation #1',
-            'Item ID',
-            $money
-        );
-        $category = Square::getSquareBuilder()->buildCategoryCatalogObject(
-            1,
-            'Category Name'
-        );
+        $variation = Square::getSquareBuilder()->buildVariationCatalogObject([
+            'name'         => 'Variation Name',
+            'variation_id' => 'Variation #1',
+            'item_id'      => 'Item ID',
+            'price_money'  => $money
+        ]);
+        $category  = Square::getSquareBuilder()->buildCategoryCatalogObject([
+            'id'   => 1,
+            'name' => 'Category Name',
+        ]);
 
         // Build the item object
-        $item = Square::getSquareBuilder()->buildItemCatalogObject(
-            $name,
-            $taxIDs,
-            $description,
-            [$variation],
-            $category->getId()
-        );
+        $item = Square::getSquareBuilder()->buildItemCatalogObject([
+            'name'        => $name,
+            'tax_ids'     => $taxIDs,
+            'description' => $description,
+            'variations'  => [$variation],
+            'category_id' => $category->getId()
+        ]);
 
         $this->assertNotNull($item);
         $this->assertInstanceOf(\Square\Models\CatalogObject::class, $item);
@@ -167,10 +170,10 @@ class SquareServiceTest extends TestCase
         $rate = 0.1;
 
         // Build the tax object
-        $tax = Square::getSquareBuilder()->buildTaxCatalogObject(
-            $name,
-            $rate
-        );
+        $tax = Square::getSquareBuilder()->buildTaxCatalogObject([
+            'name'       => $name,
+            'percentage' => $rate
+        ]);
 
         $this->assertNotNull($tax);
         $this->assertInstanceOf(\Square\Models\CatalogObject::class, $tax);
@@ -190,15 +193,18 @@ class SquareServiceTest extends TestCase
         $id     = 'Variation #1';
         $name   = 'Test Item Description';
         $itemID = 'Item #1';
-        $money  = Square::getSquareBuilder()->buildMoney(1000, Square::getCurrency());
+        $money       = Square::getSquareBuilder()->buildMoney([
+            'amount'   => 1000,
+            'currency' => Square::getCurrency()
+        ]);
 
         // Build the item object
-        $item = Square::getSquareBuilder()->buildVariationCatalogObject(
-            $name,
-            $id,
-            $itemID,
-            $money
-        );
+        $item = Square::getSquareBuilder()->buildVariationCatalogObject([
+            'name'         => $name,
+            'variation_id' => $id,
+            'item_id'      => $itemID,
+            'price_money'  => $money
+        ]);
 
         $this->assertNotNull($item);
         $this->assertInstanceOf(\Square\Models\CatalogObject::class, $item);
@@ -218,8 +224,10 @@ class SquareServiceTest extends TestCase
     {
         $amount   = 1000;
         $currency = 'USD';
-
-        $money = Square::getSquareBuilder()->buildMoney($amount, $currency);
+        $money    = Square::getSquareBuilder()->buildMoney([
+            'amount'   => $amount,
+            'currency' => $currency
+        ]);
 
         $this->assertNotNull($money);
         $this->assertInstanceOf(\Square\Models\Money::class, $money);
@@ -239,7 +247,10 @@ class SquareServiceTest extends TestCase
         $file     = \Illuminate\Http\UploadedFile::fake()->create($fileName, 100);
         $filePath = $file->getPathname();
 
-        $request = Square::getSquareBuilder()->buildCatalogImageRequest('Fake ID', 'Test caption');
+        $request = Square::getSquareBuilder()->buildCatalogImageRequest([
+            'catalog_object_id' => 'Fake ID',
+            'caption'           => 'Test caption'
+        ]);
 
         // The request below will be invalid, so make sure it throws an exception.
         $this->expectException(Exception::class);

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -34,6 +34,33 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Tests the buildCatalogImageRequest method.
+     *
+     * @return void
+     */
+    public function test_build_catalog_image_request(): void
+    {
+        // Set up the variables
+        $catalogObjectID = 'Catalog Object ID';
+        $caption         = 'Test Caption';
+
+        // Build the image request
+        $imageRequest = Square::getSquareBuilder()->buildCatalogImageRequest(
+            $catalogObjectID,
+            $caption
+        );
+
+        $this->assertNotNull($imageRequest);
+        $this->assertInstanceOf(\Square\Models\CreateCatalogImageRequest::class, $imageRequest);
+
+        $this->assertNotNull($imageRequest->getIdempotencyKey());
+        $this->assertEquals($catalogObjectID, $imageRequest->getObjectId());
+        $this->assertInstanceOf(\Square\Models\CatalogObject::class, $imageRequest->getImage());
+        $this->assertEquals($caption, $imageRequest->getImage()->getImageData()->getCaption());
+        $this->assertTrue($imageRequest->getIsPrimary());
+    }
+
+    /**
      * Tests the buildCategoryCatalogObject method.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -58,6 +58,24 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Tests the buildMoney method.
+     *
+     * @return void
+     */
+    public function test_build_money(): void
+    {
+        $amount = 1000;
+        $currency = 'USD';
+
+        $money = Square::getSquareBuilder()->buildMoney($amount, $currency);
+
+        $this->assertNotNull($money);
+        $this->assertInstanceOf(\Square\Models\Money::class, $money);
+        $this->assertEquals($amount, $money->getAmount());
+        $this->assertEquals($currency, $money->getCurrency());
+    }
+
+    /**
      * Returns the square request builder.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -2,6 +2,8 @@
 
 namespace Nikolag\Square\Tests\Unit;
 
+use Str;
+use Nikolag\Square\Builders\SquareRequestBuilder;
 use Nikolag\Square\Exception;
 use Nikolag\Square\Exceptions\InvalidSquareOrderException;
 use Nikolag\Square\Exceptions\MissingPropertyException;
@@ -19,6 +21,8 @@ use Nikolag\Square\Tests\TestCase;
 use Nikolag\Square\Tests\TestDataHolder;
 use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
+use Square\Models\BatchUpsertCatalogObjectsRequest;
+use Square\Models\BatchUpsertCatalogObjectsResponse;
 
 class SquareServiceTest extends TestCase
 {
@@ -31,6 +35,26 @@ class SquareServiceTest extends TestCase
     {
         parent::setUp();
         $this->data = TestDataHolder::make();
+    }
+
+    /**
+     * Tests the batchUpsertCatalogObjectsRequest
+     *
+     * @return void
+     */
+    public function test_batch_upsert_catalog_objects_request()
+    {
+        // Use the BatchUpsertCatalogObjectsRequestBuilder to create the request.
+        $request = \Square\Models\Builders\BatchUpsertCatalogObjectsRequestBuilder::init(
+            (string) Str::uuid(),
+            [\Square\Models\Builders\CatalogObjectBatchBuilder::init([])->build()]
+        )->build();
+
+        // The request below will be invalid, so make sure it throws an exception.
+        $this->expectException(Exception::class);
+
+        // Call the method we're testing
+        Square::batchUpsertCatalog($request);
     }
 
     /**

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -487,6 +487,19 @@ class SquareServiceTest extends TestCase
     }
 
     /**
+     * Tests retrieving a specific location.
+     *
+     * @return void
+     */
+    public function test_square_retrieve_location(): void
+    {
+        $transactions = Square::retrieveLocation('main');
+
+        $this->assertNotNull($transactions);
+        $this->assertInstanceOf('\Square\Models\RetrieveLocationResponse', $transactions);
+    }
+
+    /**
      * Save an order through facade.
      *
      * @return void

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -101,7 +101,30 @@ class SquareServiceTest extends TestCase
         $this->assertEquals($description, $item->getItemData()->getDescription());
         $this->assertEquals($variation, $item->getItemData()->getVariations()[0]);
         $this->assertEquals($category->getId(), $item->getItemData()->getCategoryId());
+    }
 
+    /**
+     * Tests the buildTaxCatalogObject method.
+     *
+     * @return void
+     */
+    public function test_build_tax_catalog_object(): void
+    {
+        // Set up the variables
+        $name = 'Test Tax Description';
+        $rate = 0.1;
+
+        // Build the tax object
+        $tax = Square::getSquareBuilder()->buildTaxCatalogObject(
+            $name,
+            $rate
+        );
+
+        $this->assertNotNull($tax);
+        $this->assertInstanceOf(\Square\Models\CatalogObject::class, $tax);
+        $this->assertEquals('TAX', $tax->getType());
+        $this->assertEquals($name, $tax->getTaxData()->getName());
+        $this->assertEquals($rate, $tax->getTaxData()->getPercentage());
     }
 
     /**

--- a/tests/unit/SquareServiceTest.php
+++ b/tests/unit/SquareServiceTest.php
@@ -23,6 +23,7 @@ use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
 use Square\Models\BatchUpsertCatalogObjectsRequest;
 use Square\Models\BatchUpsertCatalogObjectsResponse;
+use Square\Utils\FileWrapper;
 
 class SquareServiceTest extends TestCase
 {
@@ -224,6 +225,27 @@ class SquareServiceTest extends TestCase
         $this->assertInstanceOf(\Square\Models\Money::class, $money);
         $this->assertEquals($amount, $money->getAmount());
         $this->assertEquals($currency, $money->getCurrency());
+    }
+
+    /**
+     * Tests the createCatalogImage method.
+     *
+     * @return void
+     */
+    public function test_create_catalog_image(): void
+    {
+        // Create a mocked file
+        $fileName = 'image.jpg';
+        $file     = \Illuminate\Http\UploadedFile::fake()->create($fileName, 100);
+        $filePath = $file->getPathname();
+
+        $request = Square::getSquareBuilder()->buildCatalogImageRequest('Fake ID', 'Test caption');
+
+        // The request below will be invalid, so make sure it throws an exception.
+        $this->expectException(Exception::class);
+
+        // Call the method we're testing
+        $result = Square::createCatalogImage($request, $filePath);
     }
 
     /**


### PR DESCRIPTION
1. Adds access to the catalogAPI inside of the squareConfig (e.g. `Square::getConfig()->catalogAPI()`)
2. Adds builders to help with catalog-related requests
3. Adds getSquareBuilder call so we can utilize the builders outside of only the internal mechanisms of the Square facade to create more dynamic API requests.
4. Adds getCurrency, locations, retrieveLocation, createCatalogImage and batchUpsertCatalog to the Square facade
5. Adds tests