### PR TITLE
Adds support for order returns

### DIFF
--- a/src/casts/SquareOrderReturnCast.php
+++ b/src/casts/SquareOrderReturnCast.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Nikolag\Square\Casts;
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+use Square\Models\OrderReturn as SquareOrderReturn;
+
+class SquareOrderReturnCast implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): SquareOrderReturn
+    {
+        if (is_null($value)) {
+            return new SquareOrderReturn();
+        }
+
+        // Decode the JSON value into a SquareOrderReturn object
+        $decodedValue = json_decode($value, true);
+        return new SquareOrderReturn($decodedValue);
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): string
+    {
+        return json_encode($value);
+    }
+}

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -325,11 +325,17 @@ $factory->define(User::class, function (Faker\Generator $faker) {
 });
 
 /* @var \Illuminate\Database\Eloquent\Factory $factory */
-$factory->define(Constants::RETURN_NAMESPACE, function (Faker\Generator $faker) {
+$factory->define(Constants::ORDER_RETURN_NAMESPACE, function (Faker\Generator $faker) {
     return [
         'uid' => $faker->unique()->uuid,
-        'source_order_id' => function () {
-            return factory(config('nikolag.connections.square.order.namespace'))->create()->id;
+        'source_order_id' => function () use($faker) {
+            // Create a new order and spoof an id
+            $order = factory(config('nikolag.connections.square.order.namespace'))->create();
+            $property = config('nikolag.connections.square.order.service_identifier');
+            $order->{$property} = $faker->unique()->uuid;
+
+            $order->save();
+            return $order->{$property};
         },
     ];
 });

--- a/src/database/factories/ModelFactory.php
+++ b/src/database/factories/ModelFactory.php
@@ -323,3 +323,13 @@ $factory->define(User::class, function (Faker\Generator $faker) {
         'remember_token' => Str::random(10),
     ];
 });
+
+/* @var \Illuminate\Database\Eloquent\Factory $factory */
+$factory->define(Constants::RETURN_NAMESPACE, function (Faker\Generator $faker) {
+    return [
+        'uid' => $faker->unique()->uuid,
+        'source_order_id' => function () {
+            return factory(config('nikolag.connections.square.order.namespace'))->create()->id;
+        },
+    ];
+});

--- a/src/database/migrations/2025_05_31_164000_create_nikolag_order_returns_table.php
+++ b/src/database/migrations/2025_05_31_164000_create_nikolag_order_returns_table.php
@@ -13,12 +13,12 @@ return new class extends Migration
     {
         Schema::create('nikolag_order_returns', function (Blueprint $table) {
             $table->id();
-            $table->string('uid', 60)->nullable()->comment('Unique ID for the return within the order');
-            $table->string('source_order_id')->nullable()->comment('ID of the original order being returned');
+            $table->string('uid', 60)->nullable();
+            $table->string('source_order_id')->nullable();
 
             // Since we only need to read OrderReturns and cannot make new returns, just shove
             // everything else into a json field.
-            $table->json('data')->nullable()->comment('JSON data containing all other return details');
+            $table->json('data')->nullable();
 
             $table->timestamps();
 

--- a/src/database/migrations/2025_05_31_164000_create_nikolag_order_returns_table.php
+++ b/src/database/migrations/2025_05_31_164000_create_nikolag_order_returns_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('nikolag_order_returns', function (Blueprint $table) {
+            $table->id();
+            $table->string('uid', 60)->nullable()->comment('Unique ID for the return within the order');
+            $table->string('source_order_id')->nullable()->comment('ID of the original order being returned');
+
+            // Since we only need to read OrderReturns and cannot make new returns, just shove
+            // everything else into a json field.
+            $table->json('data')->nullable()->comment('JSON data containing all other return details');
+
+            $table->timestamps();
+
+            // Indexes
+            $table->index('uid');
+            $table->index('source_order_id');
+            $table->index(['source_order_id', 'uid']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('nikolag_order_returns');
+    }
+};

--- a/src/models/OrderReturn.php
+++ b/src/models/OrderReturn.php
@@ -4,6 +4,7 @@ namespace Nikolag\Square\Models;
 
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Nikolag\Square\Casts\SquareOrderReturnCast;
 
 class OrderReturn extends Model
@@ -36,6 +37,20 @@ class OrderReturn extends Model
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
+
+    //
+    // Relationships
+    //
+
+    /**
+     * Get the original order associated with this return.
+     *
+     * @return BelongsTo
+     */
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(config('nikolag.connections.square.order.namespace'), 'source_order_id', config('nikolag.connections.square.order.service_identifier'));
+    }
 
     /**
      * Prepare a date for array / JSON serialization.

--- a/src/models/OrderReturn.php
+++ b/src/models/OrderReturn.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Nikolag\Square\Models;
+
+use DateTimeInterface;
+use Illuminate\Database\Eloquent\Model;
+use Nikolag\Square\Casts\SquareOrderReturnCast;
+
+class OrderReturn extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'nikolag_order_returns';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'uid',
+        'source_order_id',
+        'data',
+    ];
+
+    /**
+     * The attributes that should be cast to native types.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'data' => SquareOrderReturnCast::class,
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * Prepare a date for array / JSON serialization.
+     *
+     * @param  \DateTimeInterface  $date
+     * @return string
+     */
+    protected function serializeDate(DateTimeInterface $date)
+    {
+        return $date->format('Y-m-d H:i:s');
+    }
+}

--- a/src/traits/HasReturns.php
+++ b/src/traits/HasReturns.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Nikolag\Square\Traits;
+
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Nikolag\Square\Models\OrderReturn;
+use Nikolag\Square\Utils\Constants;
+
+trait HasReturns
+{
+    /**
+     * Checks if this model already has a specific return.
+     *
+     * @param  mixed  $return
+     * @return bool
+     */
+    public function hasReturn(mixed $return): bool
+    {
+        $val = is_array($return)
+            ? (array_key_exists('id', $return) ? OrderReturn::find($return['id']) : $return)
+            : $return;
+
+        return $this->returns()->get()->contains($val);
+    }
+
+    /**
+     * Return the returns associated with this model.
+     *
+     * @return HasMany
+     */
+    public function returns(): HasMany
+    {
+        return $this->hasMany(Constants::ORDER_RETURN_NAMESPACE, 'source_order_id', config('nikolag.connections.square.order.service_identifier'));
+    }
+}

--- a/src/utils/Constants.php
+++ b/src/utils/Constants.php
@@ -44,6 +44,9 @@ class Constants extends CoreConstants
     //Service Charge info
     const SERVICE_CHARGE_NAMESPACE = 'Nikolag\Square\Models\ServiceCharge';
     const SERVICE_CHARGE_IDENTIFIER = 'id';
+    //Return info
+    const RETURN_NAMESPACE = 'Nikolag\Square\Models\OrderReturn';
+    const RETURN_IDENTIFIER = 'id';
 
     //Exceptions
     //INVALID_REQUEST_ERROR

--- a/src/utils/Constants.php
+++ b/src/utils/Constants.php
@@ -45,8 +45,8 @@ class Constants extends CoreConstants
     const SERVICE_CHARGE_NAMESPACE = 'Nikolag\Square\Models\ServiceCharge';
     const SERVICE_CHARGE_IDENTIFIER = 'id';
     //Return info
-    const RETURN_NAMESPACE = 'Nikolag\Square\Models\OrderReturn';
-    const RETURN_IDENTIFIER = 'id';
+    const ORDER_RETURN_NAMESPACE = 'Nikolag\Square\Models\OrderReturn';
+    const ORDER_RETURN_IDENTIFIER = 'id';
 
     //Exceptions
     //INVALID_REQUEST_ERROR

--- a/tests/TestDataHolder.php
+++ b/tests/TestDataHolder.php
@@ -139,27 +139,27 @@ class TestDataHolder
         $returnAmounts = new OrderMoneyAmounts();
 
         // Total
-        $totalMoney = $money;
+        $totalMoney = clone $money;
         $totalMoney->setAmount(20_00); // $20.00 USD
         $returnAmounts->setTotalMoney($totalMoney); // $20.00 USD
 
         // Tax
-        $taxMoney = $money;
+        $taxMoney = clone $money;
         $taxMoney->setAmount(2_00); // $2.00 USD
         $returnAmounts->setTaxMoney($taxMoney); // $2.00 USD
 
         // Discount
-        $discountMoney = $money;
+        $discountMoney = clone $money;
         $discountMoney->setAmount(1_00); // $1.00 USD
         $returnAmounts->setDiscountMoney($discountMoney); // $1.00 USD
 
         // Tip
-        $tipMoney = $money;
+        $tipMoney = clone $money;
         $tipMoney->setAmount(1_50); // $1.50 USD
         $returnAmounts->setTipMoney($tipMoney); // $1.50 USD
 
         // Service Charge
-        $serviceChargeMoney = $money;
+        $serviceChargeMoney = clone $money;
         $serviceChargeMoney->setAmount(50); // $0.50 USD
         $returnAmounts->setServiceChargeMoney($serviceChargeMoney); // $0.50 USD
 
@@ -167,9 +167,10 @@ class TestDataHolder
         $mockOrderReturn->setReturnAmounts($returnAmounts);
 
         // Set the line items
-        $lineItem1Money = $lineItem2Money = $money;
+        $lineItem1Money = clone $money;
+        $lineItem2Money = clone $money;
         $lineItem1Money->setAmount(10_00); // $10.00 USD
-        $lineItem2Money->setAmount(5_00); // $5.00 USD
+        $lineItem2Money->setAmount(3_00); // $3.00 USD
         $lineItems = [
             [
                 'uid' => 'line-item-1',

--- a/tests/TestDataHolder.php
+++ b/tests/TestDataHolder.php
@@ -11,6 +11,10 @@ use Nikolag\Square\Models\Tax;
 use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\Models\User;
 use Square\Models\FulfillmentType;
+use Square\Models\Money;
+use Square\Models\OrderMoneyAmounts;
+use Square\Models\OrderReturn as SquareOrderReturn;
+use Square\Models\OrderReturnLineItem;
 
 class TestDataHolder
 {
@@ -25,6 +29,7 @@ class TestDataHolder
         public ?Fulfillment $fulfillmentWithPickupDetails,
         public ?Fulfillment $fulfillmentWithShipmentDetails,
         public ?Recipient $fulfillmentRecipient,
+        public ?SquareOrderReturn $squareOrderReturn,
     ) {
     }
 
@@ -41,6 +46,7 @@ class TestDataHolder
             factory(Fulfillment::class)->states(FulfillmentType::PICKUP)->make(),
             factory(Fulfillment::class)->states(FulfillmentType::SHIPMENT)->make(),
             factory(Recipient::class)->make(),
+            self::buildMockOrderReturn()
         );
     }
 
@@ -58,6 +64,7 @@ class TestDataHolder
             factory(Fulfillment::class)->states(FulfillmentType::PICKUP)->make(),
             factory(Fulfillment::class)->states(FulfillmentType::SHIPMENT)->make(),
             factory(Recipient::class)->create(),
+            self::buildMockOrderReturn()
         );
     }
 
@@ -109,5 +116,91 @@ class TestDataHolder
                 'country' => 'US',
             ],
         ];
+    }
+
+
+
+    /**
+     * Builds a reusable mock OrderReturn model from square for testing.
+     *
+     * @return SquareOrderReturn
+     */
+    private static function buildMockOrderReturn(): SquareOrderReturn
+    {
+        $mockOrderReturn = new SquareOrderReturn();
+        $mockOrderReturn->setUid('mock-return-uid');
+        $mockOrderReturn->setSourceOrderId('mock-source-order-id');
+
+        // Create a re-usable money object
+        $money = new Money();
+        $money->setCurrency('USD');
+
+        // Build the order money amount that stores everything
+        $returnAmounts = new OrderMoneyAmounts();
+
+        // Total
+        $totalMoney = $money;
+        $totalMoney->setAmount(20_00); // $20.00 USD
+        $returnAmounts->setTotalMoney($totalMoney); // $20.00 USD
+
+        // Tax
+        $taxMoney = $money;
+        $taxMoney->setAmount(2_00); // $2.00 USD
+        $returnAmounts->setTaxMoney($taxMoney); // $2.00 USD
+
+        // Discount
+        $discountMoney = $money;
+        $discountMoney->setAmount(1_00); // $1.00 USD
+        $returnAmounts->setDiscountMoney($discountMoney); // $1.00 USD
+
+        // Tip
+        $tipMoney = $money;
+        $tipMoney->setAmount(1_50); // $1.50 USD
+        $returnAmounts->setTipMoney($tipMoney); // $1.50 USD
+
+        // Service Charge
+        $serviceChargeMoney = $money;
+        $serviceChargeMoney->setAmount(50); // $0.50 USD
+        $returnAmounts->setServiceChargeMoney($serviceChargeMoney); // $0.50 USD
+
+        // Set the return amounts on the mock order return
+        $mockOrderReturn->setReturnAmounts($returnAmounts);
+
+        // Set the line items
+        $lineItem1Money = $lineItem2Money = $money;
+        $lineItem1Money->setAmount(10_00); // $10.00 USD
+        $lineItem2Money->setAmount(5_00); // $5.00 USD
+        $lineItems = [
+            [
+                'uid' => 'line-item-1',
+                'source_line_item_uid' => 'source-line-item-1',
+                'name' => 'Test Item 1',
+                'quantity' => 1,
+                'total_money' => $lineItem1Money,
+            ],
+            [
+                'uid' => 'line-item-2',
+                'source_line_item_uid' => 'source-line-item-2',
+                'name' => 'Test Item 2',
+                'quantity' => 2,
+                'total_money' => $lineItem2Money,
+            ],
+        ];
+
+        $returnLineItems = [];
+        foreach ($lineItems as $item) {
+            $returnLineItem = new OrderReturnLineItem($item['quantity']);
+            $returnLineItem->setUid($item['uid']);
+            $returnLineItem->setSourceLineItemUid($item['source_line_item_uid']);
+            $returnLineItem->setName($item['name']);
+            $returnLineItem->setTotalMoney($item['total_money']);
+            $returnLineItems[] = $returnLineItem;
+        }
+        $mockOrderReturn->setReturnLineItems($returnLineItems);
+
+        // Skipping rounding adjustment for simplicity
+        // $mockOrderReturn->setRoundingAdjustment(null);
+
+        return $mockOrderReturn;
     }
 }

--- a/tests/classes/Order.php
+++ b/tests/classes/Order.php
@@ -5,11 +5,13 @@ namespace Nikolag\Square\Tests\Models;
 use Illuminate\Database\Eloquent\Model;
 use Nikolag\Square\Traits\HasFulfillments;
 use Nikolag\Square\Traits\HasProducts;
+use Nikolag\Square\Traits\HasReturns;
 
 class Order extends Model
 {
     use HasProducts;
     use HasFulfillments;
+    use HasReturns;
 
     /**
      * The table associated with the model.

--- a/tests/unit/OrderReturnTest.php
+++ b/tests/unit/OrderReturnTest.php
@@ -42,8 +42,16 @@ class OrderReturnTest extends TestCase
         $this->assertNotNull($orderReturn);
         $this->assertEquals($order->payment_service_id, $orderReturn->source_order_id);
         $this->assertEquals('test-return-uid-123', $orderReturn->uid);
-        $this->assertEquals(1500, $orderReturn->data->getReturnAmounts()->getTotalMoney()->getAmount());
+        $this->assertEquals(20_00, $orderReturn->data->getReturnAmounts()->getTotalMoney()->getAmount());
         $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getTotalMoney()->getCurrency());
+        $this->assertEquals(2_00, $orderReturn->data->getReturnAmounts()->getTaxMoney()->getAmount());
+        $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getTaxMoney()->getCurrency());
+        $this->assertEquals(1_00, $orderReturn->data->getReturnAmounts()->getDiscountMoney()->getAmount());
+        $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getDiscountMoney()->getCurrency());
+        $this->assertEquals(1_50, $orderReturn->data->getReturnAmounts()->getTipMoney()->getAmount());
+        $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getTipMoney()->getCurrency());
+        $this->assertEquals(50, $orderReturn->data->getReturnAmounts()->getServiceChargeMoney()->getAmount());
+        $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getServiceChargeMoney()->getCurrency());
     }
 
     /**

--- a/tests/unit/OrderReturnTest.php
+++ b/tests/unit/OrderReturnTest.php
@@ -28,8 +28,6 @@ class OrderReturnTest extends TestCase
 
         /** @var OrderReturn */
         $orderReturn = factory(OrderReturn::class)->make([
-            'source_order_id' => $order->id,
-            'uid' => 'test-return-uid-123',
             'data' => $this->buildMockOrderReturn(),
         ]);
 
@@ -38,6 +36,28 @@ class OrderReturnTest extends TestCase
         $this->assertEquals('test-return-uid-123', $orderReturn->uid);
         $this->assertEquals(1500, $orderReturn->data->getReturnAmounts()->getTotalMoney()->getAmount());
         $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getTotalMoney()->getCurrency());
+    }
+
+    /**
+     * Test OrderReturn relationships with Order.
+     *
+     * @return void
+     */
+    public function test_order_return_relationship_with_order(): void
+    {
+        $testUUID = fake()->unique->uuid;
+        $order = factory(Order::class)->create([
+            'payment_service_id' => $testUUID,
+        ]);
+
+        /** @var OrderReturn */
+        $orderReturn = factory(OrderReturn::class)->create([
+            'source_order_id' => $testUUID,
+            'data' => $this->buildMockOrderReturn(),
+        ]);
+
+        $this->assertInstanceOf(Order::class, $orderReturn->order);
+        $this->assertEquals($order->payment_service_id, $orderReturn->order->payment_service_id);
     }
 
     /**

--- a/tests/unit/OrderReturnTest.php
+++ b/tests/unit/OrderReturnTest.php
@@ -3,20 +3,23 @@
 namespace Nikolag\Square\Tests\Unit;
 
 use Nikolag\Square\Models\OrderReturn;
-use Nikolag\Square\Models\Product;
-use Nikolag\Square\Models\Tax;
-use Nikolag\Square\Models\Discount;
-use Nikolag\Square\Models\ServiceCharge;
 use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\TestCase;
-use Nikolag\Square\Utils\Constants;
-use Square\Models\Money;
-use Square\Models\OrderMoneyAmounts;
-use Square\Models\OrderReturn as SquareOrderReturn;
-use Square\Models\OrderReturnLineItem;
+use Nikolag\Square\Tests\TestDataHolder;
 
 class OrderReturnTest extends TestCase
 {
+    private TestDataHolder $data;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->data = TestDataHolder::create();
+    }
+
     /**
      * Test OrderReturn creation and basic properties.
      *
@@ -24,15 +27,20 @@ class OrderReturnTest extends TestCase
      */
     public function test_order_return_creation(): void
     {
-        $order = factory(Order::class)->create();
+        $testUUID = fake()->unique->uuid;
+        $order = factory(Order::class)->create([
+            'payment_service_id' => $testUUID,
+        ]);
 
         /** @var OrderReturn */
         $orderReturn = factory(OrderReturn::class)->make([
-            'data' => $this->buildMockOrderReturn(),
+            'source_order_id' => $testUUID,
+            'uid' => 'test-return-uid-123',
+            'data' => $this->data->squareOrderReturn,
         ]);
 
         $this->assertNotNull($orderReturn);
-        $this->assertEquals($order->id, $orderReturn->source_order_id);
+        $this->assertEquals($order->payment_service_id, $orderReturn->source_order_id);
         $this->assertEquals('test-return-uid-123', $orderReturn->uid);
         $this->assertEquals(1500, $orderReturn->data->getReturnAmounts()->getTotalMoney()->getAmount());
         $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getTotalMoney()->getCurrency());
@@ -53,94 +61,10 @@ class OrderReturnTest extends TestCase
         /** @var OrderReturn */
         $orderReturn = factory(OrderReturn::class)->create([
             'source_order_id' => $testUUID,
-            'data' => $this->buildMockOrderReturn(),
+            'data' => $this->data->squareOrderReturn,
         ]);
 
         $this->assertInstanceOf(Order::class, $orderReturn->order);
         $this->assertEquals($order->payment_service_id, $orderReturn->order->payment_service_id);
-    }
-
-    /**
-     * Builds a reusable mock OrderReturn model from square for testing.
-     *
-     * @return SquareOrderReturn
-     */
-    protected function buildMockOrderReturn(): SquareOrderReturn
-    {
-        $mockOrderReturn = new SquareOrderReturn();
-        $mockOrderReturn->setUid('mock-return-uid');
-        $mockOrderReturn->setSourceOrderId('mock-source-order-id');
-
-        // Create a re-usable money object
-        $money = new Money();
-        $money->setCurrency('USD');
-
-        // Build the order money amount that stores everything
-        $returnAmounts = new OrderMoneyAmounts();
-
-        // Total
-        $totalMoney = $money;
-        $totalMoney->setAmount(20_00); // $20.00 USD
-        $returnAmounts->setTotalMoney($totalMoney); // $20.00 USD
-
-        // Tax
-        $taxMoney = $money;
-        $taxMoney->setAmount(2_00); // $2.00 USD
-        $returnAmounts->setTaxMoney($taxMoney); // $2.00 USD
-
-        // Discount
-        $discountMoney = $money;
-        $discountMoney->setAmount(1_00); // $1.00 USD
-        $returnAmounts->setDiscountMoney($discountMoney); // $1.00 USD
-
-        // Tip
-        $tipMoney = $money;
-        $tipMoney->setAmount(1_50); // $1.50 USD
-        $returnAmounts->setTipMoney($tipMoney); // $1.50 USD
-
-        // Service Charge
-        $serviceChargeMoney = $money;
-        $serviceChargeMoney->setAmount(50); // $0.50 USD
-        $returnAmounts->setServiceChargeMoney($serviceChargeMoney); // $0.50 USD
-
-        // Set the return amounts on the mock order return
-        $mockOrderReturn->setReturnAmounts($returnAmounts);
-
-        // Set the line items
-        $lineItem1Money = $lineItem2Money = $money;
-        $lineItem1Money->setAmount(10_00); // $10.00 USD
-        $lineItem2Money->setAmount(5_00); // $5.00 USD
-        $lineItems = [
-            [
-                'uid' => 'line-item-1',
-                'source_line_item_uid' => 'source-line-item-1',
-                'name' => 'Test Item 1',
-                'quantity' => 1,
-                'total_money' => $lineItem1Money,
-            ],
-            [
-                'uid' => 'line-item-2',
-                'source_line_item_uid' => 'source-line-item-2',
-                'name' => 'Test Item 2',
-                'quantity' => 2,
-                'total_money' => $lineItem2Money,
-            ],
-        ];
-
-        $returnLineItems = [];
-        foreach ($lineItems as $item) {
-            $returnLineItem = new OrderReturnLineItem($item['quantity']);
-            $returnLineItem->setUid($item['uid']);
-            $returnLineItem->setSourceLineItemUid($item['source_line_item_uid']);
-            $returnLineItem->setName($item['name']);
-            $returnLineItem->setTotalMoney($item['total_money']);
-            $returnLineItems[] = $returnLineItem;
-        }
-        $mockOrderReturn->setReturnLineItems($returnLineItems);
-
-        // Skipping rounding adjustment for simplicity
-        // $mockOrderReturn->setRoundingAdjustment(null);
-
-        return $mockOrderReturn;
     }
 }

--- a/tests/unit/OrderReturnTest.php
+++ b/tests/unit/OrderReturnTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Nikolag\Square\Tests\Unit;
+
+use Nikolag\Square\Models\OrderReturn;
+use Nikolag\Square\Models\Product;
+use Nikolag\Square\Models\Tax;
+use Nikolag\Square\Models\Discount;
+use Nikolag\Square\Models\ServiceCharge;
+use Nikolag\Square\Tests\Models\Order;
+use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Utils\Constants;
+use Square\Models\Money;
+use Square\Models\OrderMoneyAmounts;
+use Square\Models\OrderReturn as SquareOrderReturn;
+use Square\Models\OrderReturnLineItem;
+
+class OrderReturnTest extends TestCase
+{
+    /**
+     * Test OrderReturn creation and basic properties.
+     *
+     * @return void
+     */
+    public function test_order_return_creation(): void
+    {
+        $order = factory(Order::class)->create();
+
+        /** @var OrderReturn */
+        $orderReturn = factory(OrderReturn::class)->make([
+            'source_order_id' => $order->id,
+            'uid' => 'test-return-uid-123',
+            'data' => $this->buildMockOrderReturn(),
+        ]);
+
+        $this->assertNotNull($orderReturn);
+        $this->assertEquals($order->id, $orderReturn->source_order_id);
+        $this->assertEquals('test-return-uid-123', $orderReturn->uid);
+        $this->assertEquals(1500, $orderReturn->data->getReturnAmounts()->getTotalMoney()->getAmount());
+        $this->assertEquals('USD', $orderReturn->data->getReturnAmounts()->getTotalMoney()->getCurrency());
+    }
+
+    /**
+     * Builds a reusable mock OrderReturn model from square for testing.
+     *
+     * @return SquareOrderReturn
+     */
+    protected function buildMockOrderReturn(): SquareOrderReturn
+    {
+        $mockOrderReturn = new SquareOrderReturn();
+        $mockOrderReturn->setUid('mock-return-uid');
+        $mockOrderReturn->setSourceOrderId('mock-source-order-id');
+
+        // Create a re-usable money object
+        $money = new Money();
+        $money->setCurrency('USD');
+
+        // Build the order money amount that stores everything
+        $returnAmounts = new OrderMoneyAmounts();
+
+        // Total
+        $totalMoney = $money;
+        $totalMoney->setAmount(20_00); // $20.00 USD
+        $returnAmounts->setTotalMoney($totalMoney); // $20.00 USD
+
+        // Tax
+        $taxMoney = $money;
+        $taxMoney->setAmount(2_00); // $2.00 USD
+        $returnAmounts->setTaxMoney($taxMoney); // $2.00 USD
+
+        // Discount
+        $discountMoney = $money;
+        $discountMoney->setAmount(1_00); // $1.00 USD
+        $returnAmounts->setDiscountMoney($discountMoney); // $1.00 USD
+
+        // Tip
+        $tipMoney = $money;
+        $tipMoney->setAmount(1_50); // $1.50 USD
+        $returnAmounts->setTipMoney($tipMoney); // $1.50 USD
+
+        // Service Charge
+        $serviceChargeMoney = $money;
+        $serviceChargeMoney->setAmount(50); // $0.50 USD
+        $returnAmounts->setServiceChargeMoney($serviceChargeMoney); // $0.50 USD
+
+        // Set the return amounts on the mock order return
+        $mockOrderReturn->setReturnAmounts($returnAmounts);
+
+        // Set the line items
+        $lineItem1Money = $lineItem2Money = $money;
+        $lineItem1Money->setAmount(10_00); // $10.00 USD
+        $lineItem2Money->setAmount(5_00); // $5.00 USD
+        $lineItems = [
+            [
+                'uid' => 'line-item-1',
+                'source_line_item_uid' => 'source-line-item-1',
+                'name' => 'Test Item 1',
+                'quantity' => 1,
+                'total_money' => $lineItem1Money,
+            ],
+            [
+                'uid' => 'line-item-2',
+                'source_line_item_uid' => 'source-line-item-2',
+                'name' => 'Test Item 2',
+                'quantity' => 2,
+                'total_money' => $lineItem2Money,
+            ],
+        ];
+
+        $returnLineItems = [];
+        foreach ($lineItems as $item) {
+            $returnLineItem = new OrderReturnLineItem($item['quantity']);
+            $returnLineItem->setUid($item['uid']);
+            $returnLineItem->setSourceLineItemUid($item['source_line_item_uid']);
+            $returnLineItem->setName($item['name']);
+            $returnLineItem->setTotalMoney($item['total_money']);
+            $returnLineItems[] = $returnLineItem;
+        }
+        $mockOrderReturn->setReturnLineItems($returnLineItems);
+
+        // Skipping rounding adjustment for simplicity
+        // $mockOrderReturn->setRoundingAdjustment(null);
+
+        return $mockOrderReturn;
+    }
+}


### PR DESCRIPTION
Because **Order Returns** are read-only (per the [docs](https://developer.squareup.com/docs/orders-api/order-returns-exchanges#overview), this simply allows for ingesting the data in as json so returns related to orders stored in your app can be queried and or stored.  Without remote-write capabilities available, there is no need to map out the data into a table, but storing everything in JSON will allow for a possible migration at some point.