### PR TITLE
Fixes calculation logic in utils

### DIFF
--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -584,16 +584,16 @@ class SquareService extends CorePaymentService implements SquareServiceContract
         foreach ($taxCatalogObjects as $taxObject) {
             $taxData = $taxObject->getTaxData();
 
-            $itemData = [
-                'name'       => $taxData->getName(),
-                'type'       => $taxData->getInclusionType(),
-                'percentage' => $taxData->getPercentage(),
-            ];
-
             $squareID = $taxObject->getId();
 
-            // Create or update the product
-            Tax::updateOrCreate(['square_catalog_object_id' => $squareID], $itemData);
+            // Lookup by (name, type) to respect the unique constraint on those columns
+            Tax::updateOrCreate(
+                ['name' => $taxData->getName(), 'type' => $taxData->getInclusionType()],
+                [
+                    'square_catalog_object_id' => $squareID,
+                    'percentage'               => $taxData->getPercentage(),
+                ]
+            );
         }
     }
 

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -1044,7 +1044,7 @@ class SquareService extends CorePaymentService implements SquareServiceContract
      *
      * @return CalculateOrderResponse
      */
-    public function calculateOrder(Model $order, string $locationId, string $currency = 'USD'): mixed
+    public function calculateOrder(mixed $order, string $locationId, string $currency = 'USD'): mixed
     {
         $request = $this->squareBuilder->buildCalculateOrderRequest($order, $locationId, $currency);
         $response = $this->config->ordersAPI()->calculateOrder($request);

--- a/src/SquareService.php
+++ b/src/SquareService.php
@@ -2,6 +2,7 @@
 
 namespace Nikolag\Square;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Nikolag\Core\Abstracts\CorePaymentService;
@@ -56,6 +57,7 @@ use Square\Models\ListPaymentsResponse;
 use Square\Models\ListWebhookEventTypesResponse;
 use Square\Models\ListWebhookSubscriptionsResponse;
 use Square\Models\RetrieveLocationResponse;
+use Square\Models\CalculateOrderResponse;
 use Square\Models\RetrieveOrderResponse;
 use Square\Models\TestWebhookSubscriptionResponse;
 use Square\Models\UpdateCustomerRequest;
@@ -1024,6 +1026,34 @@ class SquareService extends CorePaymentService implements SquareServiceContract
         } else {
             throw $this->_handleApiResponseErrors($response);
         }
+    }
+
+    /**
+     * Calculate an order using Square's CalculateOrder API.
+     *
+     * Calls Square's read-only endpoint to compute order totals including
+     * taxes, discounts, and service charges without creating an order.
+     * Used for validation against internal calculation logic.
+     *
+     * @param Model  $order      The order model to calculate.
+     * @param string $locationId The location ID for the order.
+     * @param string $currency   The currency code (default 'USD').
+     *
+     * @throws \Exception
+     * @throws ApiException
+     *
+     * @return CalculateOrderResponse
+     */
+    public function calculateOrder(Model $order, string $locationId, string $currency = 'USD'): mixed
+    {
+        $request = $this->squareBuilder->buildCalculateOrderRequest($order, $locationId, $currency);
+        $response = $this->config->ordersAPI()->calculateOrder($request);
+
+        if ($response->isError()) {
+            throw $this->_handleApiResponseErrors($response);
+        }
+
+        return $response->getResult();
     }
 
     /**

--- a/src/builders/ModifiersBuilder.php
+++ b/src/builders/ModifiersBuilder.php
@@ -27,6 +27,9 @@ class ModifiersBuilder
     {
         $temp = collect([]);
         foreach ($modifiers as $modifier) {
+            if (! $modifier instanceof Modifier && ! $modifier instanceof ModifierOption) {
+                continue;
+            }
             $modifierPivot = $this->createProductModifier($orderProduct, $modifier);
             $temp->push($modifierPivot);
         }

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -500,19 +500,6 @@ class SquareRequestBuilder
         $allServiceCharges = $this->productServiceCharges->merge($orderServiceCharges);
 
         $squareOrder->setServiceCharges($allServiceCharges->all());
-
-        // Apply LINE_ITEM-scoped service charges to all line items as appliedServiceCharges
-        $lineItemScopedCharges = $allServiceCharges->filter(
-            fn ($sc) => $sc->getScope() === Constants::DEDUCTIBLE_SCOPE_PRODUCT
-        );
-        if ($lineItemScopedCharges->isNotEmpty()) {
-            $appliedRefs = $this->buildAppliedServiceCharges($lineItemScopedCharges);
-            foreach ($lineItems as $lineItem) {
-                $existing = $lineItem->getAppliedServiceCharges() ?? [];
-                $lineItem->setAppliedServiceCharges(array_merge($existing, $appliedRefs));
-            }
-        }
-
         $squareOrder->setLineItems($lineItems);
 
         // Merge service charge taxes into the order-level taxes

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -72,6 +72,12 @@ class SquareRequestBuilder
      */
     private Collection $serviceCharges;
     /**
+     * Taxes applied to service charges which need to be added to order-level taxes.
+     *
+     * @var Collection
+     */
+    private Collection $serviceChargeTaxes;
+    /**
      * Fulfillment request helper builder.
      *
      * @var FulfillmentRequestBuilder
@@ -726,6 +732,32 @@ class SquareRequestBuilder
                     $money->setAmount($amountMoney);
                     $money->setCurrency($serviceCharge->amount_currency ?? $currency);
                     $tempServiceCharge->amountMoney($money);
+                }
+
+                // Build taxes applied to this service charge
+                $serviceCharge->loadMissing('taxes');
+                $scTaxes = $serviceCharge->taxes ?? collect([]);
+                if ($scTaxes->isNotEmpty()) {
+                    $appliedTaxes = [];
+                    foreach ($scTaxes as $tax) {
+                        $tempTax = new OrderLineItemTax();
+                        $tempTax->setUid(Util::uid());
+                        $tempTax->setName($tax->name);
+                        $tempTax->setType($tax->type);
+                        $tempTax->setPercentage((string) $tax->percentage);
+                        // Use LINE_ITEM scope so the tax only applies where explicitly referenced
+                        // (on the service charge via applied_taxes), not to all line items
+                        $tempTax->setScope(Constants::DEDUCTIBLE_SCOPE_PRODUCT);
+                        if ($tax->square_catalog_object_id) {
+                            $tempTax->setCatalogObjectId($tax->square_catalog_object_id);
+                        }
+                        $this->serviceChargeTaxes->push($tempTax);
+
+                        $appliedTax = new OrderLineItemAppliedTax($tempTax->getUid());
+                        $appliedTax->setUid(Util::uid());
+                        $appliedTaxes[] = $appliedTax;
+                    }
+                    $tempServiceCharge->appliedTaxes($appliedTaxes);
                 }
 
                 $temp[] = $tempServiceCharge->build();

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -28,6 +28,7 @@ use Square\Models\CatalogObjectType;
 use Square\Models\CatalogPricingType;
 use Square\Models\CreateCatalogImageRequest;
 use Square\Models\CreateCustomerRequest;
+use Square\Models\CalculateOrderRequest;
 use Square\Models\CreateOrderRequest;
 use Square\Models\CreatePaymentRequest;
 use Square\Models\Money;
@@ -93,6 +94,7 @@ class SquareRequestBuilder
         $this->productDiscounts = collect([]);
         $this->serviceCharges = collect([]);
         $this->productServiceCharges = collect([]);
+        $this->serviceChargeTaxes = collect([]);
 
         $this->fulfillmentRequestBuilder = new FulfillmentRequestBuilder();
     }
@@ -446,6 +448,25 @@ class SquareRequestBuilder
         return $request;
     }
 
+    /**
+     * Create and return a calculate order request for validating pricing
+     * against Square's CalculateOrder API without creating an order.
+     *
+     * @param Model  $order
+     * @param string $locationId
+     * @param string $currency
+     *
+     * @throws InvalidSquareOrderException
+     * @throws MissingPropertyException
+     *
+     * @return CalculateOrderRequest
+     */
+    public function buildCalculateOrderRequest(Model $order, string $locationId, string $currency): CalculateOrderRequest
+    {
+        $squareOrder = $this->buildSquareOrder($order, $locationId, $currency);
+
+        return new CalculateOrderRequest($squareOrder);
+    }
 
     /**
      * Build a Square Order object with line items, discounts, taxes,

--- a/src/builders/SquareRequestBuilder.php
+++ b/src/builders/SquareRequestBuilder.php
@@ -407,18 +407,7 @@ class SquareRequestBuilder
      */
     public function buildOrderRequest(Model $order, string $locationId, string $currency): CreateOrderRequest
     {
-        $squareOrder = new Order($locationId);
-        $squareOrder->setReferenceId($order->id);
-        $squareOrder->setLineItems($this->buildProducts($order->products, $currency));
-        $squareOrder->setDiscounts($this->buildDiscounts($order->discounts, $currency));
-        $squareOrder->setTaxes($this->buildTaxes($order->taxes));
-        $squareOrder->setFulfillments($this->fulfillmentRequestBuilder->buildFulfillments($order->fulfillments));
-
-        // Merge the product level service charges into the main service charges collection
-        $orderServiceCharges = collect($this->buildServiceCharges($order->serviceCharges, $currency));
-        $allServiceCharges = $this->productServiceCharges->merge($orderServiceCharges);
-
-        $squareOrder->setServiceCharges($allServiceCharges->all());
+        $squareOrder = $this->buildSquareOrder($order, $locationId, $currency);
 
         $request = new CreateOrderRequest();
         $request->setOrder($squareOrder);
@@ -445,13 +434,44 @@ class SquareRequestBuilder
         $serviceIdentifierProperty = config('nikolag.connections.square.order.service_identifier');
         $referenceIdProperty = config('nikolag.connections.square.order.reference_id');
 
-        $squareOrder = new Order($locationId);
+        $squareOrder = $this->buildSquareOrder($order, $locationId, $currency);
         $squareOrder->setId($order->{$serviceIdentifierProperty});
         $squareOrder->setReferenceId($order->{$referenceIdProperty});
         $squareOrder->setVersion($version);
-        $squareOrder->setLineItems($this->buildProducts($order->products, $currency));
+
+        $request = new UpdateOrderRequest();
+        $request->setOrder($squareOrder);
+        $request->setIdempotencyKey(uniqid());
+
+        return $request;
+    }
+
+
+    /**
+     * Build a Square Order object with line items, discounts, taxes,
+     * fulfillments, and service charges from a local order model.
+     *
+     * @param Model  $order
+     * @param string $locationId
+     * @param string $currency
+     *
+     * @throws InvalidSquareOrderException
+     * @throws MissingPropertyException
+     *
+     * @return Order
+     */
+    private function buildSquareOrder(Model $order, string $locationId, string $currency): Order
+    {
+        // Reset accumulated collections from any previous build call
+        $this->productTaxes = collect([]);
+        $this->productDiscounts = collect([]);
+        $this->productServiceCharges = collect([]);
+        $this->serviceChargeTaxes = collect([]);
+
+        $squareOrder = new Order($locationId);
+        $squareOrder->setReferenceId($order->id);
+        $lineItems = $this->buildProducts($order->products, $currency);
         $squareOrder->setDiscounts($this->buildDiscounts($order->discounts, $currency));
-        $squareOrder->setTaxes($this->buildTaxes($order->taxes));
         $squareOrder->setFulfillments($this->fulfillmentRequestBuilder->buildFulfillments($order->fulfillments));
 
         // Merge the product level service charges into the main service charges collection
@@ -460,11 +480,26 @@ class SquareRequestBuilder
 
         $squareOrder->setServiceCharges($allServiceCharges->all());
 
-        $request = new UpdateOrderRequest();
-        $request->setOrder($squareOrder);
-        $request->setIdempotencyKey(uniqid());
+        // Apply LINE_ITEM-scoped service charges to all line items as appliedServiceCharges
+        $lineItemScopedCharges = $allServiceCharges->filter(
+            fn ($sc) => $sc->getScope() === Constants::DEDUCTIBLE_SCOPE_PRODUCT
+        );
+        if ($lineItemScopedCharges->isNotEmpty()) {
+            $appliedRefs = $this->buildAppliedServiceCharges($lineItemScopedCharges);
+            foreach ($lineItems as $lineItem) {
+                $existing = $lineItem->getAppliedServiceCharges() ?? [];
+                $lineItem->setAppliedServiceCharges(array_merge($existing, $appliedRefs));
+            }
+        }
 
-        return $request;
+        $squareOrder->setLineItems($lineItems);
+
+        // Merge service charge taxes into the order-level taxes
+        $orderTaxes = collect($this->buildTaxes($order->taxes));
+        $allTaxes = $orderTaxes->merge($this->serviceChargeTaxes);
+        $squareOrder->setTaxes($allTaxes->all());
+
+        return $squareOrder;
     }
 
     /**

--- a/src/contracts/SquareServiceContract.php
+++ b/src/contracts/SquareServiceContract.php
@@ -67,4 +67,15 @@ interface SquareServiceContract extends PaymentServiceContract
      * @return self
      */
     public function setOrder(mixed $order, string $locationId, string $currency = 'USD'): SquareServiceContract;
+
+    /**
+     * Calculate an order using Square's CalculateOrder API endpoint.
+     *
+     * @param mixed  $order
+     * @param string $locationId
+     * @param string $currency
+     *
+     * @return mixed
+     */
+    public function calculateOrder(mixed $order, string $locationId, string $currency = 'USD'): mixed;
 }

--- a/src/traits/HasProducts.php
+++ b/src/traits/HasProducts.php
@@ -3,6 +3,7 @@
 namespace Nikolag\Square\Traits;
 
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Support\Facades\Schema;
 use Nikolag\Core\Exceptions\Exception;
@@ -130,6 +131,17 @@ trait HasProducts
         ], $attributes);
 
         $this->products()->attach($product, $pivotData);
+    }
+
+    /**
+     * Return all line items for this order, including custom line items
+     * that have no linked product.
+     *
+     * @return HasMany
+     */
+    public function lineItems(): HasMany
+    {
+        return $this->hasMany(Constants::ORDER_PRODUCT_NAMESPACE, 'order_id');
     }
 
     /**

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Nikolag\Square\Models\Fulfillment;
+use Nikolag\Square\Models\OrderProductPivot;
 use Nikolag\Square\Models\Product;
 use Nikolag\Square\Models\Tax;
 use Square\Models\OrderServiceChargeCalculationPhase;
@@ -146,7 +147,7 @@ class Util
             // Calculate and round the product taxes
             $productTaxes = $netPrice * ($tax->percentage / 100);
 
-            return round($productTaxes);
+            return self::_roundMoney($productTaxes);
         } else {
             return 0;
         }
@@ -169,7 +170,7 @@ class Util
         // Get the order taxes
         $orderTaxes = $netPrice * $tax->percentage / 100;
 
-        return round($orderTaxes);
+        return self::_roundMoney($orderTaxes);
     }
 
     /**
@@ -183,7 +184,7 @@ class Util
      */
     private static function _calculateOrderServiceCharges($serviceCharge, float $amount): float|int
     {
-        return ($serviceCharge->percentage) ? round($amount * $serviceCharge->percentage / 100) :
+        return ($serviceCharge->percentage) ? self::_roundMoney($amount * $serviceCharge->percentage / 100) :
             $serviceCharge->amount_money;
     }
 
@@ -296,14 +297,14 @@ class Util
             $serviceChargeAmount = match ($scope) {
                 Constants::DEDUCTIBLE_SCOPE_PRODUCT => self::_calculateProductServiceCharges($products, $serviceCharge),
                 Constants::DEDUCTIBLE_SCOPE_ORDER   => $serviceCharge->percentage ?
-                    round($serviceCharge->percentage / 100 * self::_getOrderBaseAmount($products)) :
+                    self::_roundMoney($serviceCharge->percentage / 100 * self::_getOrderBaseAmount($products)) :
                     $serviceCharge->amount_money,
                 default => 0
             };
 
             // Apply taxes to the service charge amount
             return $serviceChargeTaxes->sum(function ($tax) use ($serviceChargeAmount) {
-                return round($serviceChargeAmount * $tax->percentage / 100);
+                return self::_roundMoney($serviceChargeAmount * $tax->percentage / 100);
             });
         });
     }
@@ -538,9 +539,453 @@ class Util
      */
     public static function calculateTotalOrderCostByModel(Model $order): float|int
     {
+        $order->loadMissing(['lineItems']);
+
+        if ($order->lineItems->count() > 1) {
+            return $order->lineItems->sum(
+                fn (OrderProductPivot $lineItem) => self::calculateLineItemTotalByModel($lineItem, $order)
+            );
+        }
+
         $allServiceCharges = self::collectServiceCharges($order);
 
         return self::_calculateTotalCost($order->discounts, $order->taxes, $allServiceCharges, $order->products);
+    }
+
+    /**
+     * Calculate the total cost for a single line item, including its apportioned
+     * share of order-level taxes, discounts, and service charges.
+     *
+     * Mirrors Square's per-line-item total calculation: order-level adjustments
+     * are apportioned proportionally by gross sales ratio.
+     *
+     * @param OrderProductPivot $lineItem The line item to calculate.
+     * @param Model             $order    The parent order (for order-level deductibles).
+     *
+     * @return float|int The total cost for this line item in cents.
+     */
+    public static function calculateLineItemTotalByModel(OrderProductPivot $lineItem, Model $order): float|int
+    {
+        $lineItem->loadMissing(['taxes', 'discounts', 'serviceCharges', 'modifiers.modifiable']);
+        $order->loadMissing(['lineItems.modifiers.modifiable', 'lineItems.serviceCharges', 'discounts', 'taxes']);
+
+        $allServiceCharges = self::collectServiceCharges($order);
+        $allLineItems = $order->lineItems;
+
+        return self::_calculateLineItemTotal($lineItem, $order->discounts, $order->taxes, $allServiceCharges, $allLineItems);
+    }
+
+    /**
+     * Core calculation pipeline for a single line item.
+     *
+     * Follows the same sequence as _calculateTotalCost:
+     * base cost → discounts → subtotal service charges → subtotal taxes
+     * → total service charges → total taxes → service charge taxes
+     *
+     * ORDER-scoped deductibles are apportioned by gross sales ratio.
+     *
+     * @param OrderProductPivot $lineItem
+     * @param Collection        $orderDiscounts
+     * @param Collection        $orderTaxes
+     * @param Collection        $orderServiceCharges
+     * @param Collection        $allLineItems
+     *
+     * @return float|int
+     */
+    private static function _calculateLineItemTotal(
+        OrderProductPivot $lineItem,
+        Collection $orderDiscounts,
+        Collection $orderTaxes,
+        Collection $orderServiceCharges,
+        Collection $allLineItems
+    ): float|int {
+        // Step 1: Base cost for this line item
+        $lineItemBaseCost = self::_calculateLineItemBaseCost($lineItem);
+
+        // Step 2: Apportionment ratio (this line item's share of order gross sales)
+        $orderBaseCost = self::_calculateAllLineItemsBaseCost($allLineItems);
+        $ratio = ($orderBaseCost > 0) ? $lineItemBaseCost / $orderBaseCost : 0;
+
+        // Step 3: Collect all applicable deductibles for this line item
+        $isCustomLineItem = is_null($lineItem->product_id);
+
+        // Line-item-scoped deductibles (directly attached to this line item)
+        $lineItemDiscounts = self::_mergeCollectionsByScope($lineItem->discounts ?? collect([]));
+        $lineItemTaxes = self::_mergeCollectionsByScope($lineItem->taxes ?? collect([]));
+        $lineItemServiceCharges = self::_mergeCollectionsByScope($lineItem->serviceCharges ?? collect([]));
+
+        // Order-scoped deductibles
+        $orderScopedDiscounts = self::_filterOrderScoped($orderDiscounts);
+        $orderScopedTaxes = self::_filterOrderScoped($orderTaxes);
+
+        // For custom line items, only include ORDER taxes that apply to custom amounts
+        if ($isCustomLineItem) {
+            $orderScopedTaxes = $orderScopedTaxes->filter(
+                fn (Tax $tax) => $tax->appliesToCustomAmounts()
+            );
+        }
+
+        $orderScopedServiceCharges = self::_filterOrderScoped($orderServiceCharges);
+
+        // Merge all applicable deductibles
+        $allDiscounts = $lineItemDiscounts->merge($orderScopedDiscounts);
+        $allTaxes = $lineItemTaxes->merge($orderScopedTaxes);
+        $allServiceCharges = $lineItemServiceCharges->merge($orderScopedServiceCharges);
+
+        // Step 4: Separate taxes by calculation phase
+        $subtotalPhaseTaxes = $allTaxes->filter(fn (Tax $tax) => $tax->isCalculatedOnSubtotal());
+        $totalPhaseTaxes = $allTaxes->filter(fn (Tax $tax) => $tax->isCalculatedOnTotal());
+
+        // Step 5: Separate service charges by calculation phase
+        $subtotalServiceCharges = $allServiceCharges->filter(fn ($sc) => in_array($sc->calculation_phase, [
+            OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE,
+            OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE,
+            OrderServiceChargeCalculationPhase::APPORTIONED_PERCENTAGE_PHASE,
+        ]));
+        $totalServiceCharges = $allServiceCharges->filter(
+            fn ($sc) => $sc->calculation_phase === OrderServiceChargeCalculationPhase::TOTAL_PHASE
+        );
+
+        // Step 6: Apply discounts
+        $discountAmount = self::_calculateLineItemDiscounts($allDiscounts, $lineItemBaseCost, $ratio);
+        $discountedCost = $lineItemBaseCost - $discountAmount;
+
+        // Step 7: Add subtotal-phase service charges
+        $subtotalServiceChargeBreakdown = self::_calculateLineItemServiceChargeBreakdown(
+            $subtotalServiceCharges,
+            $discountedCost,
+            $lineItem,
+            $allLineItems,
+            $ratio
+        );
+        $subtotalSCAmount = $subtotalServiceChargeBreakdown->sum('amount');
+        $subtotalAmount = $discountedCost + $subtotalSCAmount;
+
+        // Step 8: Add subtotal-phase taxes
+        $subtotalTaxAmount = self::_calculateLineItemTaxes($subtotalPhaseTaxes, $subtotalAmount);
+        $subtotalTaxedCost = $subtotalAmount + $subtotalTaxAmount;
+
+        // Step 9: Add total-phase service charges
+        $totalServiceChargeBreakdown = self::_calculateLineItemServiceChargeBreakdown(
+            $totalServiceCharges,
+            $subtotalTaxedCost,
+            $lineItem,
+            $allLineItems,
+            $ratio
+        );
+        $totalSCAmount = $totalServiceChargeBreakdown->sum('amount');
+        $preTotal = $subtotalTaxedCost + $totalSCAmount;
+
+        // Step 10: Add total-phase taxes
+        $totalTaxAmount = self::_calculateLineItemTaxes($totalPhaseTaxes, $preTotal);
+        $totalTaxedCost = $preTotal + $totalTaxAmount;
+
+        // Step 11: Add service charge taxes
+        $scTaxAmount = self::_calculateLineItemServiceChargeTaxes(
+            $subtotalServiceChargeBreakdown->merge($totalServiceChargeBreakdown)
+        );
+
+        return $totalTaxedCost + $scTaxAmount;
+    }
+
+    /**
+     * Calculate base cost for a single line item: (base_price + modifiers) × quantity.
+     *
+     * @param OrderProductPivot $lineItem
+     *
+     * @return float|int
+     */
+    private static function _calculateLineItemBaseCost(OrderProductPivot $lineItem): float|int
+    {
+        $basePrice = $lineItem->base_price_money_amount ?? 0;
+
+        $modifierCost = 0;
+        if ($lineItem->modifiers && $lineItem->modifiers->isNotEmpty()) {
+            $modifierCost = $lineItem->modifiers->sum(
+                fn ($modifier) => $modifier->modifiable?->price_money_amount ?? 0
+            );
+        }
+
+        return ($basePrice + $modifierCost) * ($lineItem->quantity ?? 1);
+    }
+
+    /**
+     * Sum base costs across all line items for the apportionment denominator.
+     *
+     * @param Collection $lineItems Collection of OrderProductPivot
+     *
+     * @return float|int
+     */
+    private static function _calculateAllLineItemsBaseCost(Collection $lineItems): float|int
+    {
+        return $lineItems->sum(fn (OrderProductPivot $li) => self::_calculateLineItemBaseCost($li));
+    }
+
+    /**
+     * Filter a collection of deductibles to only ORDER-scoped items.
+     *
+     * @param Collection $deductibles
+     *
+     * @return Collection
+     */
+    private static function _filterOrderScoped(Collection $deductibles): Collection
+    {
+        return $deductibles->filter(function ($item) {
+            $scope = $item->pivot ? $item->pivot->scope : $item->scope;
+
+            return $scope === Constants::DEDUCTIBLE_SCOPE_ORDER;
+        });
+    }
+
+    /**
+     * Calculate discounts for a single line item.
+     *
+     * Percentage discounts apply their percentage to this line item's base cost.
+     * Fixed-amount ORDER-scoped discounts are apportioned by gross sales ratio.
+     * Fixed-amount LINE_ITEM-scoped discounts apply their full amount.
+     *
+     * @param Collection $discounts
+     * @param float|int  $lineItemBaseCost
+     * @param float      $ratio Apportionment ratio for ORDER-scoped fixed amounts
+     *
+     * @return float|int Total discount amount
+     */
+    private static function _calculateLineItemDiscounts(Collection $discounts, float|int $lineItemBaseCost, float $ratio): float|int
+    {
+        if ($discounts->isEmpty()) {
+            return 0;
+        }
+
+        $runningAmount = $lineItemBaseCost;
+        $totalDiscount = 0;
+
+        $discountGroups = [
+            fn ($discount) => ($discount->pivot ? $discount->pivot->scope : $discount->scope) === Constants::DEDUCTIBLE_SCOPE_PRODUCT && $discount->percentage,
+            fn ($discount) => ($discount->pivot ? $discount->pivot->scope : $discount->scope) === Constants::DEDUCTIBLE_SCOPE_ORDER && $discount->percentage,
+            fn ($discount) => ($discount->pivot ? $discount->pivot->scope : $discount->scope) === Constants::DEDUCTIBLE_SCOPE_PRODUCT && !$discount->percentage,
+            fn ($discount) => ($discount->pivot ? $discount->pivot->scope : $discount->scope) === Constants::DEDUCTIBLE_SCOPE_ORDER && !$discount->percentage,
+        ];
+
+        foreach ($discountGroups as $groupFilter) {
+            foreach ($discounts->filter($groupFilter) as $discount) {
+                $scope = $discount->pivot ? $discount->pivot->scope : $discount->scope;
+                $discountAmount = $discount->percentage
+                    ? self::_roundMoney($runningAmount * $discount->percentage / 100)
+                    : ($scope === Constants::DEDUCTIBLE_SCOPE_ORDER
+                        ? self::_roundMoney(($discount->amount ?? 0) * $ratio)
+                        : ($discount->amount ?? 0));
+
+                $discountAmount = min($discountAmount, $runningAmount);
+                $totalDiscount += $discountAmount;
+                $runningAmount -= $discountAmount;
+            }
+        }
+
+        return $totalDiscount;
+    }
+
+    /**
+     * Calculate additive taxes for a single line item.
+     *
+     * Inclusive taxes reduce the net price base; additive taxes are added on top.
+     *
+     * @param Collection $taxes
+     * @param float|int  $baseAmount The amount to apply taxes to
+     *
+     * @return float|int Total tax amount
+     */
+    private static function _calculateLineItemTaxes(Collection $taxes, float|int $baseAmount): float|int
+    {
+        if ($taxes->isEmpty()) {
+            return 0;
+        }
+
+        $additiveTaxes = $taxes->filter(fn ($tax) => $tax->type === Constants::TAX_ADDITIVE);
+        $inclusiveTaxes = $taxes->filter(fn ($tax) => $tax->type === Constants::TAX_INCLUSIVE);
+
+        if ($additiveTaxes->isEmpty()) {
+            return 0;
+        }
+
+        // Calculate net price by removing inclusive taxes
+        $netPrice = self::_calculateNetPrice($baseAmount, $inclusiveTaxes);
+
+        return (int) $additiveTaxes->sum(
+            fn ($tax) => round($netPrice * $tax->percentage / 100)
+        );
+    }
+
+    /**
+     * Calculate service charges for a single line item.
+     *
+     * ORDER-scoped percentage charges apply to this line item's base amount.
+     * ORDER-scoped fixed charges are apportioned by gross sales ratio.
+     * APPORTIONED_AMOUNT charges use amount × lineItem quantity.
+     * APPORTIONED_PERCENTAGE charges use percentage × base amount.
+     * LINE_ITEM-scoped charges apply directly.
+     *
+     * @param Collection        $serviceCharges
+     * @param float|int         $baseAmount Current line item subtotal
+     * @param OrderProductPivot $lineItem
+     * @param float             $ratio Apportionment ratio
+     *
+     * @return float|int Total service charge amount
+     */
+    private static function _calculateLineItemServiceChargeBreakdown(
+        Collection $serviceCharges,
+        float|int $baseAmount,
+        OrderProductPivot $lineItem,
+        Collection $allLineItems,
+        float $ratio
+    ): Collection {
+        if ($serviceCharges->isEmpty()) {
+            return collect([]);
+        }
+
+        return $serviceCharges->map(function ($sc) use ($baseAmount, $lineItem, $allLineItems, $ratio) {
+            return [
+                'service_charge' => $sc,
+                'amount'         => self::_calculateLineItemServiceChargeAmount($sc, $baseAmount, $lineItem, $allLineItems, $ratio),
+            ];
+        });
+    }
+
+    /**
+     * Calculate taxes on service charges for a single line item.
+     *
+     * Only applies to non-APPORTIONED_TREATMENT, taxable service charges.
+     * The service charge amount attributable to this line item is taxed.
+     *
+     * @param Collection        $serviceCharges
+     * @param OrderProductPivot $lineItem
+     * @param float             $ratio Apportionment ratio
+     *
+     * @return float|int
+     */
+    private static function _calculateLineItemServiceChargeTaxes(Collection $serviceChargeBreakdown): float|int
+    {
+        if ($serviceChargeBreakdown->isEmpty()) {
+            return 0;
+        }
+
+        return $serviceChargeBreakdown->sum(function (array $serviceChargeData) {
+            /** @var mixed $sc */
+            $sc = $serviceChargeData['service_charge'];
+            $scAmount = $serviceChargeData['amount'];
+
+            // Apportioned service charges inherit taxes from line items — no direct taxes
+            if (
+                $sc->treatment_type === OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT
+                || $sc->taxable === false
+            ) {
+                return 0;
+            }
+
+            $scTaxes = $sc->taxes ?? collect([]);
+            if ($scTaxes->isEmpty()) {
+                return 0;
+            }
+
+            // Apply each tax to the service charge amount
+            return $scTaxes->sum(fn ($tax) => self::_roundMoney($scAmount * $tax->percentage / 100));
+        });
+    }
+
+    /**
+     * Calculate a single service charge amount attributable to one line item.
+     *
+     * @param mixed             $serviceCharge
+     * @param float|int         $baseAmount
+     * @param OrderProductPivot $lineItem
+     * @param Collection        $allLineItems
+     * @param float             $ratio
+     *
+     * @return int
+     */
+    private static function _calculateLineItemServiceChargeAmount(
+        $serviceCharge,
+        float|int $baseAmount,
+        OrderProductPivot $lineItem,
+        Collection $allLineItems,
+        float $ratio
+    ): int {
+        $scope = $serviceCharge->pivot ? $serviceCharge->pivot->scope : $serviceCharge->scope;
+
+        if ($serviceCharge->calculation_phase === OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE) {
+            $apportionmentRatio = self::_calculateLineItemServiceChargeRatio($serviceCharge, $lineItem, $allLineItems, $ratio);
+
+            return self::_roundMoney(($serviceCharge->amount_money ?? 0) * $apportionmentRatio);
+        }
+
+        if ($serviceCharge->calculation_phase === OrderServiceChargeCalculationPhase::APPORTIONED_PERCENTAGE_PHASE) {
+            return self::_roundMoney($baseAmount * ($serviceCharge->percentage ?? 0) / 100);
+        }
+
+        if ($scope === Constants::DEDUCTIBLE_SCOPE_ORDER) {
+            if ($serviceCharge->percentage) {
+                return self::_roundMoney($baseAmount * $serviceCharge->percentage / 100);
+            }
+
+            return self::_roundMoney(($serviceCharge->amount_money ?? 0) * $ratio);
+        }
+
+        if ($serviceCharge->percentage) {
+            return self::_roundMoney($baseAmount * $serviceCharge->percentage / 100);
+        }
+
+        return (int) ($serviceCharge->amount_money ?? 0);
+    }
+
+    /**
+     * Calculate the applicable apportionment ratio for a service charge.
+     *
+     * @param mixed             $serviceCharge
+     * @param OrderProductPivot $lineItem
+     * @param Collection        $allLineItems
+     * @param float             $defaultRatio
+     *
+     * @return float
+     */
+    private static function _calculateLineItemServiceChargeRatio(
+        $serviceCharge,
+        OrderProductPivot $lineItem,
+        Collection $allLineItems,
+        float $defaultRatio
+    ): float {
+        $scope = $serviceCharge->pivot ? $serviceCharge->pivot->scope : $serviceCharge->scope;
+
+        if ($scope === Constants::DEDUCTIBLE_SCOPE_ORDER) {
+            return $defaultRatio;
+        }
+
+        $applicableLineItems = $allLineItems->filter(function (OrderProductPivot $candidate) use ($serviceCharge) {
+            $candidate->loadMissing('serviceCharges');
+
+            return $candidate->serviceCharges->contains(fn ($attachedServiceCharge) => $attachedServiceCharge->id === $serviceCharge->id);
+        });
+
+        if ($applicableLineItems->isEmpty()) {
+            return 0;
+        }
+
+        $applicableBaseCost = self::_calculateAllLineItemsBaseCost($applicableLineItems);
+        if ($applicableBaseCost <= 0) {
+            return 0;
+        }
+
+        return self::_calculateLineItemBaseCost($lineItem) / $applicableBaseCost;
+    }
+
+    /**
+     * Round monetary adjustments using Square's documented bankers' rounding.
+     *
+     * @param float|int $amount
+     *
+     * @return int
+     */
+    private static function _roundMoney(float|int $amount): int
+    {
+        return (int) round($amount, 0, PHP_ROUND_HALF_EVEN);
     }
 
     /**

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -637,16 +637,13 @@ class Util
         }
 
         $orderScopedServiceCharges = self::_filterOrderScoped($orderServiceCharges);
-        $productScopedServiceCharges = $orderServiceCharges->filter(function ($item) {
-            $scope = $item->pivot ? $item->pivot->scope : $item->scope;
-
-            return $scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT;
-        });
 
         // Merge all applicable deductibles
+        // PRODUCT-scoped service charges are already in $lineItemServiceCharges (from the pivot)
+        // — they must NOT be pulled from the order-wide collection, which would apply them to every line item
         $allDiscounts = $lineItemDiscounts->merge($orderScopedDiscounts);
         $allTaxes = $lineItemTaxes->merge($orderScopedTaxes);
-        $allServiceCharges = $lineItemServiceCharges->merge($orderScopedServiceCharges)->merge($productScopedServiceCharges);
+        $allServiceCharges = $lineItemServiceCharges->merge($orderScopedServiceCharges);
 
         // Step 4: Separate taxes by calculation phase
         $subtotalPhaseTaxes = $allTaxes->filter(fn (Tax $tax) => $tax->isCalculatedOnSubtotal());
@@ -675,10 +672,14 @@ class Util
             $ratio
         );
         $subtotalSCAmount = $subtotalServiceChargeBreakdown->sum('amount');
+        $taxableSubtotalSCAmount = $subtotalServiceChargeBreakdown
+            ->filter(fn (array $entry) => $entry['service_charge']->taxable)
+            ->sum('amount');
         $subtotalAmount = $discountedCost + $subtotalSCAmount;
 
-        // Step 8: Add subtotal-phase taxes
-        $subtotalTaxAmount = self::_calculateLineItemTaxes($subtotalPhaseTaxes, $subtotalAmount);
+        // Step 8: Add subtotal-phase taxes (only taxable service charges are included in the tax base)
+        $subtotalTaxBase = $discountedCost + $taxableSubtotalSCAmount;
+        $subtotalTaxAmount = self::_calculateLineItemTaxes($subtotalPhaseTaxes, $subtotalTaxBase);
         $subtotalTaxedCost = $subtotalAmount + $subtotalTaxAmount;
 
         // Step 9: Add total-phase service charges
@@ -690,10 +691,14 @@ class Util
             $ratio
         );
         $totalSCAmount = $totalServiceChargeBreakdown->sum('amount');
+        $taxableTotalSCAmount = $totalServiceChargeBreakdown
+            ->filter(fn (array $entry) => $entry['service_charge']->taxable)
+            ->sum('amount');
         $preTotal = $subtotalTaxedCost + $totalSCAmount;
 
         // Step 10: Add total-phase taxes (on pre-tax subtotal + total service charges, not compounded)
-        $totalTaxBase = $subtotalAmount + $totalSCAmount;
+        // Only taxable service charges are included in the tax base
+        $totalTaxBase = $subtotalTaxBase + $taxableTotalSCAmount;
         $totalTaxAmount = self::_calculateLineItemTaxes($totalPhaseTaxes, $totalTaxBase);
         $totalTaxedCost = $preTotal + $totalTaxAmount;
 

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -448,18 +448,27 @@ class Util
         $discountCost = $noDeductiblesCost - self::_calculateDiscounts($allDiscounts, $noDeductiblesCost, $products);
 
         // Add subtotal-phase service charges to discount cost
-        $subTotalAmount = $discountCost + self::_calculateServiceCharges($subtotalServiceCharges, $discountCost, $products);
+        $subtotalSCAmount = self::_calculateServiceCharges($subtotalServiceCharges, $discountCost, $products);
+        $taxableSubtotalSCAmount = self::_calculateServiceCharges(
+            $subtotalServiceCharges->filter(fn ($sc) => $sc->taxable), $discountCost, $products
+        );
+        $subTotalAmount = $discountCost + $subtotalSCAmount;
 
-        // Apply subtotal-phase taxes (before total-phase service charges)
-        $subtotalTaxedCost = $subTotalAmount + self::_calculateAdditiveTaxes($subtotalPhaseTaxes, $subTotalAmount, $products, $allDiscounts);
+        // Apply subtotal-phase taxes (only taxable service charges are included in the tax base)
+        $subtotalTaxBase = $discountCost + $taxableSubtotalSCAmount;
+        $subtotalTaxedCost = $subTotalAmount + self::_calculateAdditiveTaxes($subtotalPhaseTaxes, $subtotalTaxBase, $products, $allDiscounts);
 
         // Add total-phase service charges after subtotal taxes
         $totalServiceChargeAmount = self::_calculateServiceCharges($totalServiceCharges, $subtotalTaxedCost, $products);
+        $taxableTotalSCAmount = self::_calculateServiceCharges(
+            $totalServiceCharges->filter(fn ($sc) => $sc->taxable), $subtotalTaxedCost, $products
+        );
         $preTotal = $subtotalTaxedCost + $totalServiceChargeAmount;
 
         // Apply total-phase taxes to the pre-tax subtotal + total service charges
         // (taxes are not compounded on each other — Square applies each phase's taxes independently)
-        $totalTaxBase = $subTotalAmount + $totalServiceChargeAmount;
+        // Only taxable service charges are included in the tax base
+        $totalTaxBase = $subtotalTaxBase + $taxableTotalSCAmount;
         $totalTaxedCost = $preTotal + self::_calculateAdditiveTaxes($totalPhaseTaxes, $totalTaxBase, $products, $allDiscounts);
 
         // Finally, calculate service charge taxes

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -92,7 +92,7 @@ class Util
      */
     private static function _calculateOrderDiscounts($discount, float $noDeductiblesCost): float|int
     {
-        return ($discount->percentage) ? ($noDeductiblesCost * $discount->percentage / 100) :
+        return ($discount->percentage) ? self::_roundMoney($noDeductiblesCost * $discount->percentage / 100) :
             $discount->amount;
     }
 
@@ -112,7 +112,7 @@ class Util
         });
 
         if ($product) {
-            return ($discount->percentage) ? ($product->pivot->base_price_money_amount * $product->pivot->quantity * $discount->percentage / 100) :
+            return ($discount->percentage) ? self::_roundMoney($product->pivot->base_price_money_amount * $product->pivot->quantity * $discount->percentage / 100) :
                 $discount->amount;
         } else {
             return 0;
@@ -811,7 +811,7 @@ class Util
         $netPrice = self::_calculateNetPrice($baseAmount, $inclusiveTaxes);
 
         return (int) $additiveTaxes->sum(
-            fn ($tax) => round($netPrice * $tax->percentage / 100)
+            fn ($tax) => self::_roundMoney($netPrice * $tax->percentage / 100)
         );
     }
 
@@ -912,6 +912,11 @@ class Util
         $scope = $serviceCharge->pivot ? $serviceCharge->pivot->scope : $serviceCharge->scope;
 
         if ($serviceCharge->calculation_phase === OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE) {
+            // PRODUCT-scoped: apply fixed amount per unit (matches _calculateProductServiceCharges behavior)
+            if ($scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT) {
+                return self::_roundMoney(($serviceCharge->amount_money ?? 0) * ($lineItem->quantity ?? 1));
+            }
+
             $apportionmentRatio = self::_calculateLineItemServiceChargeRatio($serviceCharge, $lineItem, $allLineItems, $ratio);
 
             return self::_roundMoney(($serviceCharge->amount_money ?? 0) * $apportionmentRatio);

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -933,6 +933,14 @@ class Util
     ): int {
         $scope = $serviceCharge->pivot ? $serviceCharge->pivot->scope : $serviceCharge->scope;
 
+        // SUBTOTAL_PHASE is an order-level calculation phase — it cannot be applied to individual products
+        if (
+            $scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT
+            && $serviceCharge->calculation_phase === OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE
+        ) {
+            throw new Exception('Service charge calculation phase "SUBTOTAL" cannot be applied to products in an order.');
+        }
+
         if ($serviceCharge->calculation_phase === OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE) {
             // PRODUCT-scoped: apply fixed amount per unit (matches _calculateProductServiceCharges behavior)
             if ($scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT) {

--- a/src/utils/Util.php
+++ b/src/utils/Util.php
@@ -457,8 +457,10 @@ class Util
         $totalServiceChargeAmount = self::_calculateServiceCharges($totalServiceCharges, $subtotalTaxedCost, $products);
         $preTotal = $subtotalTaxedCost + $totalServiceChargeAmount;
 
-        // Apply total-phase taxes (after service charges)
-        $totalTaxedCost = $preTotal + self::_calculateAdditiveTaxes($totalPhaseTaxes, $preTotal, $products, $allDiscounts);
+        // Apply total-phase taxes to the pre-tax subtotal + total service charges
+        // (taxes are not compounded on each other — Square applies each phase's taxes independently)
+        $totalTaxBase = $subTotalAmount + $totalServiceChargeAmount;
+        $totalTaxedCost = $preTotal + self::_calculateAdditiveTaxes($totalPhaseTaxes, $totalTaxBase, $products, $allDiscounts);
 
         // Finally, calculate service charge taxes
         $serviceChargeTaxAmount = self::_calculateServiceChargeTaxes($allServiceCharges, $products);
@@ -626,11 +628,16 @@ class Util
         }
 
         $orderScopedServiceCharges = self::_filterOrderScoped($orderServiceCharges);
+        $productScopedServiceCharges = $orderServiceCharges->filter(function ($item) {
+            $scope = $item->pivot ? $item->pivot->scope : $item->scope;
+
+            return $scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT;
+        });
 
         // Merge all applicable deductibles
         $allDiscounts = $lineItemDiscounts->merge($orderScopedDiscounts);
         $allTaxes = $lineItemTaxes->merge($orderScopedTaxes);
-        $allServiceCharges = $lineItemServiceCharges->merge($orderScopedServiceCharges);
+        $allServiceCharges = $lineItemServiceCharges->merge($orderScopedServiceCharges)->merge($productScopedServiceCharges);
 
         // Step 4: Separate taxes by calculation phase
         $subtotalPhaseTaxes = $allTaxes->filter(fn (Tax $tax) => $tax->isCalculatedOnSubtotal());
@@ -676,8 +683,9 @@ class Util
         $totalSCAmount = $totalServiceChargeBreakdown->sum('amount');
         $preTotal = $subtotalTaxedCost + $totalSCAmount;
 
-        // Step 10: Add total-phase taxes
-        $totalTaxAmount = self::_calculateLineItemTaxes($totalPhaseTaxes, $preTotal);
+        // Step 10: Add total-phase taxes (on pre-tax subtotal + total service charges, not compounded)
+        $totalTaxBase = $subtotalAmount + $totalSCAmount;
+        $totalTaxAmount = self::_calculateLineItemTaxes($totalPhaseTaxes, $totalTaxBase);
         $totalTaxedCost = $preTotal + $totalTaxAmount;
 
         // Step 11: Add service charge taxes

--- a/tests/Traits/AssertsSquareCalculation.php
+++ b/tests/Traits/AssertsSquareCalculation.php
@@ -62,6 +62,22 @@ trait AssertsSquareCalculation
     }
 
     /**
+     * Validate internal calculation against Square's CalculateOrder API when enabled.
+     *
+     * Gated behind SQUARE_VALIDATE_CALCULATIONS env flag so tests run fast by default
+     * and only hit the Square API when explicitly opted in.
+     *
+     * @param object $order         The order model with relationships loaded.
+     * @param int    $internalTotal The internally calculated total.
+     */
+    protected function validateAgainstSquareApi(object $order, int $internalTotal): void
+    {
+        if (env('SQUARE_VALIDATE_CALCULATIONS', false)) {
+            $this->assertMatchesSquareCalculation($order, $internalTotal);
+        }
+    }
+
+    /**
      * Validate internal calculation against Square's CalculateOrder API.
      *
      * @param mixed $order         The order model with relationships loaded.

--- a/tests/Traits/AssertsSquareCalculation.php
+++ b/tests/Traits/AssertsSquareCalculation.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Nikolag\Square\Tests\Traits;
+
+use Nikolag\Square\Facades\Square;
+use Square\Models\CalculateOrderResponse;
+
+/**
+ * Provides helpers for comparing internal order totals against Square's CalculateOrder API.
+ *
+ * Used for troubleshooting and validating that our local calculation logic
+ * matches Square's server-side results.
+ */
+trait AssertsSquareCalculation
+{
+    /**
+     * Compare an internal order total calculation with Square's CalculateOrder API response.
+     *
+     * Returns a structured array showing whether the totals match and a breakdown
+     * of Square's calculation components for debugging discrepancies.
+     *
+     * @param float|int              $internalTotal  The total from calculateTotalOrderCost()/calculateTotalOrderCostByModel().
+     * @param CalculateOrderResponse $squareResponse The response from Square's CalculateOrder API.
+     *
+     * @return array{
+     *   matches: bool,
+     *   internal_total: int,
+     *   square_total: int|null,
+     *   difference: int,
+     *   square_breakdown: array{
+     *     total_money: int|null,
+     *     total_tax_money: int|null,
+     *     total_discount_money: int|null,
+     *     total_service_charge_money: int|null,
+     *   }
+     * }
+     */
+    private function compareWithSquareCalculation(float|int $internalTotal, CalculateOrderResponse $squareResponse): array
+    {
+        $squareOrder = $squareResponse->getOrder();
+
+        $squareTotal = $squareOrder?->getTotalMoney()?->getAmount();
+        $squareTaxTotal = $squareOrder?->getTotalTaxMoney()?->getAmount();
+        $squareDiscountTotal = $squareOrder?->getTotalDiscountMoney()?->getAmount();
+        $squareServiceChargeTotal = $squareOrder?->getTotalServiceChargeMoney()?->getAmount();
+
+        $internalTotalInt = (int) $internalTotal;
+        $difference = $squareTotal !== null ? $internalTotalInt - $squareTotal : 0;
+
+        return [
+            'matches'          => $squareTotal !== null && $internalTotalInt === $squareTotal,
+            'internal_total'   => $internalTotalInt,
+            'square_total'     => $squareTotal,
+            'difference'       => $difference,
+            'square_breakdown' => [
+                'total_money'                => $squareTotal,
+                'total_tax_money'            => $squareTaxTotal,
+                'total_discount_money'       => $squareDiscountTotal,
+                'total_service_charge_money' => $squareServiceChargeTotal,
+            ],
+        ];
+    }
+
+    /**
+     * Validate internal calculation against Square's CalculateOrder API.
+     *
+     * @param mixed $order         The order model with relationships loaded.
+     * @param int   $internalTotal The internally calculated total.
+     */
+    private function assertMatchesSquareCalculation($order, int $internalTotal): void
+    {
+        $order->loadMissing('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');
+        $squareResponse = Square::calculateOrder($order, env('SQUARE_LOCATION'));
+        $comparison = $this->compareWithSquareCalculation($internalTotal, $squareResponse);
+        $this->assertTrue(
+            $comparison['matches'],
+            sprintf(
+                'Internal total (%d) does not match Square total (%d). Difference: %d. Square breakdown: tax=%d, discount=%d, service_charge=%d',
+                $comparison['internal_total'],
+                $comparison['square_total'],
+                $comparison['difference'],
+                $comparison['square_breakdown']['total_tax_money'] ?? 0,
+                $comparison['square_breakdown']['total_discount_money'] ?? 0,
+                $comparison['square_breakdown']['total_service_charge_money'] ?? 0
+            )
+        );
+    }
+}

--- a/tests/Traits/MocksSquareConfigDependency.php
+++ b/tests/Traits/MocksSquareConfigDependency.php
@@ -14,6 +14,7 @@ use Square\Apis\WebhookSubscriptionsApi;
 use Square\Http\ApiResponse;
 use Square\Models\Builders\CreateCustomerResponseBuilder;
 use Square\Models\Builders\CreateInvoiceResponseBuilder;
+use Square\Models\Builders\CalculateOrderResponseBuilder;
 use Square\Models\Builders\CreateOrderResponseBuilder;
 use Square\Models\Builders\CreateWebhookSubscriptionResponseBuilder;
 use Square\Models\Builders\CustomerBuilder;
@@ -36,6 +37,7 @@ use Square\Models\Builders\UpdateWebhookSubscriptionSignatureKeyResponseBuilder;
 use Square\Models\Builders\WebhookSubscriptionBuilder;
 use Square\Models\CreateCustomerResponse;
 use Square\Models\CreateInvoiceResponse;
+use Square\Models\CalculateOrderResponse;
 use Square\Models\CreateOrderResponse;
 use Square\Models\CreateWebhookSubscriptionResponse;
 use Square\Models\DeleteWebhookSubscriptionResponse;
@@ -736,6 +738,8 @@ trait MocksSquareConfigDependency
                 return $this->buildCreateOrderResponse($data);
             case 'updateOrder':
                 return $this->buildUpdateOrderResponse($data);
+            case 'calculateOrder':
+                return $this->buildCalculateOrderResponse($data);
             default:
                 return $this->buildRetrieveOrderResponse($data);
         }
@@ -962,6 +966,70 @@ trait MocksSquareConfigDependency
         $mockApiResponse->method('getStatusCode')->willReturn(409);
 
         $this->bindMockOrdersToServiceContainer('updateOrder', $mockApiResponse);
+    }
+
+    /**
+     * Build a calculate order response.
+     *
+     * @param array|null $data The data to include in the response.
+     *
+     * @return CalculateOrderResponse
+     */
+    private function buildCalculateOrderResponse(?array $data = null): CalculateOrderResponse
+    {
+        $orderData = $data ?? [
+            'locationId'              => 'test-location-123',
+            'state'                   => 'OPEN',
+            'totalMoney'              => 0,
+            'totalTaxMoney'           => 0,
+            'totalDiscountMoney'      => 0,
+            'totalServiceChargeMoney' => 0,
+        ];
+
+        $builder = OrderBuilder::init($orderData['locationId'])
+            ->state($orderData['state'] ?? 'OPEN');
+
+        if (isset($orderData['totalMoney'])) {
+            $builder->totalMoney(MoneyBuilder::init()->amount($orderData['totalMoney'])->currency('USD')->build());
+        }
+        if (isset($orderData['totalTaxMoney'])) {
+            $builder->totalTaxMoney(MoneyBuilder::init()->amount($orderData['totalTaxMoney'])->currency('USD')->build());
+        }
+        if (isset($orderData['totalDiscountMoney'])) {
+            $builder->totalDiscountMoney(MoneyBuilder::init()->amount($orderData['totalDiscountMoney'])->currency('USD')->build());
+        }
+        if (isset($orderData['totalServiceChargeMoney'])) {
+            $builder->totalServiceChargeMoney(MoneyBuilder::init()->amount($orderData['totalServiceChargeMoney'])->currency('USD')->build());
+        }
+
+        return CalculateOrderResponseBuilder::init()
+            ->order($builder->build())
+            ->build();
+    }
+
+    /**
+     * Mock the ordersAPI()->calculateOrder($request) method in the SquareService class.
+     *
+     * @param array $responseData Data to include in the successful response.
+     *
+     * @return void
+     */
+    protected function mockCalculateOrderSuccess(array $responseData = []): void
+    {
+        $this->mockSquareOrdersEndpoint('calculateOrder', $responseData);
+    }
+
+    /**
+     * Mock the ordersAPI()->calculateOrder($request) method with error in the SquareService class.
+     *
+     * @param string $message Error message to return.
+     * @param int    $code    HTTP error code to return.
+     *
+     * @return void
+     */
+    protected function mockCalculateOrderError(string $message = 'Calculate order failed', int $code = 400): void
+    {
+        $this->mockSquareOrdersEndpoint('calculateOrder', [], true, $message, $code);
     }
 
     // ========================================

--- a/tests/unit/CalculateOrderTest.php
+++ b/tests/unit/CalculateOrderTest.php
@@ -1,0 +1,548 @@
+<?php
+
+namespace Nikolag\Square\Tests\Unit;
+
+use Nikolag\Square\Facades\Square;
+use Nikolag\Square\Models\Discount;
+use Nikolag\Square\Models\Product;
+use Nikolag\Square\Models\Product as ModelsProduct;
+use Nikolag\Square\Models\ServiceCharge;
+use Nikolag\Square\Models\Tax;
+use Nikolag\Square\Tests\Models\Order;
+use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Tests\Traits\MocksSquareConfigDependency;
+use Nikolag\Square\Utils\Constants;
+use Nikolag\Square\Utils\Util;
+use Square\Models\Builders\CalculateOrderResponseBuilder;
+use Square\Models\Builders\MoneyBuilder;
+use Square\Models\Builders\OrderBuilder;
+use Square\Models\CalculateOrderRequest;
+use Square\Models\CalculateOrderResponse;
+use Square\Models\OrderServiceChargeCalculationPhase;
+use Square\Models\OrderServiceChargeTreatmentType;
+
+class CalculateOrderTest extends TestCase
+{
+    use MocksSquareConfigDependency;
+
+    /**
+     * Test that buildCalculateOrderRequest returns a valid CalculateOrderRequest.
+     */
+    public function test_build_calculate_order_request(): void
+    {
+        $order = factory(Order::class)->create();
+        $product = factory(Product::class)->create(['price' => 1500]);
+
+        $tax = factory(Tax::class)->create([
+            'percentage' => 8.5,
+            'type'       => Constants::TAX_ADDITIVE,
+        ]);
+
+        $discount = factory(Discount::class)->create([
+            'percentage' => 10.0,
+            'amount'     => null,
+        ]);
+
+        $square = Square::setOrder($order, env('SQUARE_LOCATION'))
+            ->addProduct($product, 2)
+            ->save();
+
+        $order->taxes()->attach($tax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $order->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $order->refresh();
+        $order->load('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');
+
+        $squareBuilder = Square::getSquareBuilder();
+        $request = $squareBuilder->buildCalculateOrderRequest($order, env('SQUARE_LOCATION'), 'USD');
+
+        $this->assertInstanceOf(CalculateOrderRequest::class, $request);
+
+        $squareOrder = $request->getOrder();
+        $this->assertNotNull($squareOrder);
+        $this->assertNotEmpty($squareOrder->getLineItems());
+        $this->assertNotEmpty($squareOrder->getTaxes());
+        $this->assertNotEmpty($squareOrder->getDiscounts());
+    }
+
+    /**
+     * Test that buildOrderRequest still works after the refactor.
+     */
+    public function test_build_order_request_after_refactor(): void
+    {
+        $order = factory(Order::class)->create();
+        $product = factory(Product::class)->create(['price' => 2000]);
+
+        $serviceCharge = factory(ServiceCharge::class)->create([
+            'name'              => 'Test Fee',
+            'amount_money'      => 500,
+            'amount_currency'   => 'USD',
+            'calculation_phase' => OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ]);
+
+        $square = Square::setOrder($order, env('SQUARE_LOCATION'))
+            ->addProduct($product, 1)
+            ->save();
+
+        $order->serviceCharges()->attach($serviceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $order->refresh();
+        $order->load('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');
+
+        $squareBuilder = Square::getSquareBuilder();
+        $request = $squareBuilder->buildOrderRequest($order, env('SQUARE_LOCATION'), 'USD');
+
+        $this->assertNotNull($request->getOrder());
+        $this->assertNotEmpty($request->getOrder()->getLineItems());
+        $this->assertNotNull($request->getIdempotencyKey());
+    }
+
+    /**
+     * Test calculateOrder service method with mocked success response.
+     */
+    public function test_calculate_order_success(): void
+    {
+        $this->mockCalculateOrderSuccess([
+            'locationId'              => env('SQUARE_LOCATION'),
+            'state'                   => 'OPEN',
+            'totalMoney'              => 4671,
+            'totalTaxMoney'           => 349,
+            'totalDiscountMoney'      => 400,
+            'totalServiceChargeMoney' => 722,
+        ]);
+
+        $order = factory(Order::class)->create();
+        $product = factory(Product::class)->create(['price' => 1000]);
+
+        Square::setOrder($order, env('SQUARE_LOCATION'))
+            ->addProduct($product, 1)
+            ->save();
+
+        $order->refresh();
+        $order->load('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');
+
+        $response = Square::calculateOrder($order, env('SQUARE_LOCATION'));
+
+        $this->assertInstanceOf(CalculateOrderResponse::class, $response);
+        $this->assertNotNull($response->getOrder());
+        $this->assertEquals(4671, $response->getOrder()->getTotalMoney()->getAmount());
+    }
+
+    /**
+     * Test calculateOrder service method with mocked error response.
+     */
+    public function test_calculate_order_error(): void
+    {
+        $this->mockCalculateOrderError('Invalid order data', 400);
+
+        $order = factory(Order::class)->create();
+        $product = factory(Product::class)->create(['price' => 1000]);
+
+        Square::setOrder($order, env('SQUARE_LOCATION'))
+            ->addProduct($product, 1)
+            ->save();
+
+        $order->refresh();
+        $order->load('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');
+
+        $this->expectException(\Exception::class);
+
+        Square::calculateOrder($order, env('SQUARE_LOCATION'));
+    }
+
+    /**
+     * Test compareWithSquareCalculation when totals match.
+     */
+    public function test_compare_with_square_calculation_matches(): void
+    {
+        $squareResponse = CalculateOrderResponseBuilder::init()
+            ->order(
+                OrderBuilder::init('test-location')
+                    ->totalMoney(MoneyBuilder::init()->amount(4671)->currency('USD')->build())
+                    ->totalTaxMoney(MoneyBuilder::init()->amount(349)->currency('USD')->build())
+                    ->totalDiscountMoney(MoneyBuilder::init()->amount(400)->currency('USD')->build())
+                    ->totalServiceChargeMoney(MoneyBuilder::init()->amount(722)->currency('USD')->build())
+                    ->build()
+            )
+            ->build();
+
+        $result = Util::compareWithSquareCalculation(4671, $squareResponse);
+
+        $this->assertTrue($result['matches']);
+        $this->assertEquals(4671, $result['internal_total']);
+        $this->assertEquals(4671, $result['square_total']);
+        $this->assertEquals(0, $result['difference']);
+        $this->assertEquals(349, $result['square_breakdown']['total_tax_money']);
+        $this->assertEquals(400, $result['square_breakdown']['total_discount_money']);
+        $this->assertEquals(722, $result['square_breakdown']['total_service_charge_money']);
+    }
+
+    /**
+     * Test compareWithSquareCalculation when totals do not match.
+     */
+    public function test_compare_with_square_calculation_mismatch(): void
+    {
+        $squareResponse = CalculateOrderResponseBuilder::init()
+            ->order(
+                OrderBuilder::init('test-location')
+                    ->totalMoney(MoneyBuilder::init()->amount(4670)->currency('USD')->build())
+                    ->totalTaxMoney(MoneyBuilder::init()->amount(348)->currency('USD')->build())
+                    ->totalDiscountMoney(MoneyBuilder::init()->amount(400)->currency('USD')->build())
+                    ->totalServiceChargeMoney(MoneyBuilder::init()->amount(722)->currency('USD')->build())
+                    ->build()
+            )
+            ->build();
+
+        $result = Util::compareWithSquareCalculation(4671, $squareResponse);
+
+        $this->assertFalse($result['matches']);
+        $this->assertEquals(4671, $result['internal_total']);
+        $this->assertEquals(4670, $result['square_total']);
+        $this->assertEquals(1, $result['difference']);
+    }
+
+    /**
+     * Test compareWithSquareCalculation when Square response has no order.
+     */
+    public function test_compare_with_square_calculation_null_order(): void
+    {
+        $squareResponse = CalculateOrderResponseBuilder::init()->build();
+
+        $result = Util::compareWithSquareCalculation(4671, $squareResponse);
+
+        $this->assertFalse($result['matches']);
+        $this->assertNull($result['square_total']);
+        $this->assertEquals(0, $result['difference']);
+    }
+
+    /**
+     * Validate internal calculation against Square's CalculateOrder API
+     * using the same scenario as test_service_charge_integration_with_full_order_workflow
+     * but with Square-valid calculation phases.
+     *
+     * Scenario:
+     *   - Product 1: $10.00 x 2 = $20.00
+     *   - Product 2: $20.00 x 1 = $20.00
+     *   - Subtotal: $40.00
+     *   - 10% order-level discount
+     *   - $5.00 apportioned-amount service charge (APPORTIONED_AMOUNT_PHASE)
+     *   - 5% apportioned-percentage service charge on first product (APPORTIONED_PERCENTAGE_PHASE)
+     *   - 8.5% additive tax (order-level)
+     *
+     * @group live
+     */
+    public function test_validate_full_workflow_against_square_calculate_order(): void
+    {
+        // Create test data - mirrors ServiceChargeIntegrationTest exactly
+        $order = factory(Order::class)->create();
+        $product1 = factory(ModelsProduct::class)->create(['price' => 10_00]); // $10.00
+        $product2 = factory(Product::class)->create(['price' => 20_00]); // $20.00
+
+        // Create service charges using Square-valid calculation phases:
+        // - Amount-based apportioned charges must use APPORTIONED_AMOUNT_PHASE
+        // - Percentage-based apportioned charges must use APPORTIONED_PERCENTAGE_PHASE
+        $orderServiceCharge = factory(ServiceCharge::class)->create([
+            'name'              => 'Handling Fee',
+            'amount_money'      => 5_00, // $5.00
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ]);
+
+        $productServiceCharge = factory(ServiceCharge::class)->create([
+            'name'              => 'Fake Percentage Fee',
+            'percentage'        => 5.0,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_PERCENTAGE_PHASE,
+            'taxable'           => false,
+        ]);
+
+        // Create tax and discount
+        $tax = factory(Tax::class)->create([
+            'percentage' => 8.5,
+            'type'       => Constants::TAX_ADDITIVE,
+        ]);
+
+        $discount = factory(Discount::class)->create([
+            'percentage' => 10.0,
+            'amount'     => null,
+        ]);
+
+        // Build order through Square service
+        Square::setOrder($order, env('SQUARE_LOCATION'))
+            ->addProduct($product1, 2) // 2 x $10.00 = $20.00
+            ->addProduct($product2, 1) // 1 x $20.00 = $20.00
+            ->save();
+
+        // Attach order-level service charge
+        $order->serviceCharges()->attach($orderServiceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        // Attach product-level service charge to first product
+        $order->products->first()->pivot->serviceCharges()->attach($productServiceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        // Attach tax and discount at order level
+        $order->taxes()->attach($tax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $order->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        // Refresh the order to get updated relationships
+        $order->refresh();
+        $order->load('products', 'serviceCharges', 'taxes', 'discounts', 'fulfillments');
+
+        // Calculate using our internal logic
+        $internalTotal = Util::calculateTotalOrderCostByModel($order);
+
+        // Send to Square's CalculateOrder endpoint for validation
+        $squareResponse = Square::calculateOrder($order, env('SQUARE_LOCATION'));
+
+        // Compare internal vs Square
+        $comparison = Util::compareWithSquareCalculation($internalTotal, $squareResponse);
+
+        // Assert that our calculation matches Square's
+        $this->assertTrue(
+            $comparison['matches'],
+            sprintf(
+                'Internal total (%d) does not match Square total (%d). Difference: %d. Square breakdown: tax=%d, discount=%d, service_charge=%d',
+                $comparison['internal_total'],
+                $comparison['square_total'],
+                $comparison['difference'],
+                $comparison['square_breakdown']['total_tax_money'] ?? 0,
+                $comparison['square_breakdown']['total_discount_money'] ?? 0,
+                $comparison['square_breakdown']['total_service_charge_money'] ?? 0
+            )
+        );
+    }
+
+    // ========================================================================
+    // Service charge combination validation against Square's CalculateOrder API
+    // ========================================================================
+
+    /**
+     * Helper: create an order with products, attach a service charge, and validate against Square.
+     */
+    private function assertServiceChargeMatchesSquare(array $serviceChargeAttrs, string $scope = Constants::DEDUCTIBLE_SCOPE_ORDER): void
+    {
+        $order = factory(Order::class)->create();
+        $product1 = factory(Product::class)->create(['price' => 15_00]);
+        $product2 = factory(Product::class)->create(['price' => 50_00]);
+
+        Square::setOrder($order, env('SQUARE_LOCATION'))
+            ->addProduct($product1, 2) // $30.00
+            ->addProduct($product2, 1) // $50.00
+            ->save();
+
+        $serviceCharge = factory(ServiceCharge::class)->create($serviceChargeAttrs);
+
+        $order->serviceCharges()->attach($serviceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => $scope,
+        ]);
+
+        $order->refresh();
+        $order->load('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');
+
+        $internalTotal = Util::calculateTotalOrderCostByModel($order);
+        $squareResponse = Square::calculateOrder($order, env('SQUARE_LOCATION'));
+        $comparison = Util::compareWithSquareCalculation($internalTotal, $squareResponse);
+
+        $this->assertTrue(
+            $comparison['matches'],
+            sprintf(
+                '[%s] Internal=%d, Square=%d, Diff=%d. Square: tax=%d, discount=%d, sc=%d',
+                $serviceChargeAttrs['name'] ?? 'unnamed',
+                $comparison['internal_total'],
+                $comparison['square_total'],
+                $comparison['difference'],
+                $comparison['square_breakdown']['total_tax_money'] ?? 0,
+                $comparison['square_breakdown']['total_discount_money'] ?? 0,
+                $comparison['square_breakdown']['total_service_charge_money'] ?? 0
+            )
+        );
+    }
+
+    /**
+     * SUBTOTAL_PHASE + LINE_ITEM_TREATMENT + fixed amount (ORDER scope)
+     *
+     * @group live
+     */
+    public function test_sc_subtotal_line_item_fixed_order(): void
+    {
+        $this->assertServiceChargeMatchesSquare([
+            'name'              => 'Subtotal/LineItem/Fixed/Order',
+            'amount_money'      => 5_00,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::LINE_ITEM_TREATMENT,
+            'taxable'           => false,
+        ]);
+    }
+
+    /**
+     * SUBTOTAL_PHASE + LINE_ITEM_TREATMENT + percentage (ORDER scope)
+     *
+     * @group live
+     */
+    public function test_sc_subtotal_line_item_percentage_order(): void
+    {
+        $this->assertServiceChargeMatchesSquare([
+            'name'              => 'Subtotal/LineItem/Percentage/Order',
+            'percentage'        => 10.0,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::LINE_ITEM_TREATMENT,
+            'taxable'           => false,
+        ]);
+    }
+
+    /**
+     * APPORTIONED_AMOUNT_PHASE + APPORTIONED_TREATMENT + fixed amount (ORDER scope)
+     *
+     * @group live
+     */
+    public function test_sc_apportioned_amount_order(): void
+    {
+        $this->assertServiceChargeMatchesSquare([
+            'name'              => 'ApportionedAmount/Order',
+            'amount_money'      => 10_00,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ]);
+    }
+
+    /**
+     * APPORTIONED_PERCENTAGE_PHASE + APPORTIONED_TREATMENT + percentage (ORDER scope)
+     *
+     * @group live
+     */
+    public function test_sc_apportioned_percentage_order(): void
+    {
+        $this->assertServiceChargeMatchesSquare([
+            'name'              => 'ApportionedPercentage/Order',
+            'percentage'        => 8.0,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_PERCENTAGE_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ]);
+    }
+
+    /**
+     * APPORTIONED_AMOUNT_PHASE + APPORTIONED_TREATMENT + fixed amount (LINE_ITEM scope)
+     *
+     * @group live
+     */
+    public function test_sc_apportioned_amount_line_item(): void
+    {
+        $this->assertServiceChargeMatchesSquare([
+            'name'              => 'ApportionedAmount/LineItem',
+            'amount_money'      => 10_00,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ], Constants::DEDUCTIBLE_SCOPE_PRODUCT);
+    }
+
+    /**
+     * APPORTIONED_PERCENTAGE_PHASE + APPORTIONED_TREATMENT + percentage (LINE_ITEM scope)
+     *
+     * @group live
+     */
+    public function test_sc_apportioned_percentage_line_item(): void
+    {
+        $this->assertServiceChargeMatchesSquare([
+            'name'              => 'ApportionedPercentage/LineItem',
+            'percentage'        => 8.0,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_PERCENTAGE_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ], Constants::DEDUCTIBLE_SCOPE_PRODUCT);
+    }
+
+    /**
+     * SUBTOTAL_PHASE + LINE_ITEM_TREATMENT + taxable fixed amount (ORDER scope)
+     *
+     * @group live
+     */
+    public function test_sc_subtotal_taxable_fixed_order(): void
+    {
+        $order = factory(Order::class)->create();
+        $product = factory(Product::class)->create(['price' => 100_00]);
+
+        Square::setOrder($order, env('SQUARE_LOCATION'))
+            ->addProduct($product, 1)
+            ->save();
+
+        $tax = factory(Tax::class)->create([
+            'percentage' => 10.0,
+            'type'       => Constants::TAX_ADDITIVE,
+        ]);
+
+        $serviceCharge = factory(ServiceCharge::class)->create([
+            'name'              => 'Taxable Subtotal Fee',
+            'amount_money'      => 5_00,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::LINE_ITEM_TREATMENT,
+            'taxable'           => true,
+        ]);
+
+        $order->taxes()->attach($tax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+        $order->serviceCharges()->attach($serviceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $order->refresh();
+        $order->load('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');
+
+        $internalTotal = Util::calculateTotalOrderCostByModel($order);
+        $squareResponse = Square::calculateOrder($order, env('SQUARE_LOCATION'));
+        $comparison = Util::compareWithSquareCalculation($internalTotal, $squareResponse);
+
+        $this->assertTrue(
+            $comparison['matches'],
+            sprintf(
+                'Taxable SC: Internal=%d, Square=%d, Diff=%d. Square: tax=%d, sc=%d',
+                $comparison['internal_total'],
+                $comparison['square_total'],
+                $comparison['difference'],
+                $comparison['square_breakdown']['total_tax_money'] ?? 0,
+                $comparison['square_breakdown']['total_service_charge_money'] ?? 0
+            )
+        );
+    }
+}

--- a/tests/unit/CalculateOrderTest.php
+++ b/tests/unit/CalculateOrderTest.php
@@ -10,6 +10,7 @@ use Nikolag\Square\Models\ServiceCharge;
 use Nikolag\Square\Models\Tax;
 use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Tests\Traits\AssertsSquareCalculation;
 use Nikolag\Square\Tests\Traits\MocksSquareConfigDependency;
 use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
@@ -23,6 +24,7 @@ use Square\Models\OrderServiceChargeTreatmentType;
 
 class CalculateOrderTest extends TestCase
 {
+    use AssertsSquareCalculation;
     use MocksSquareConfigDependency;
 
     /**
@@ -181,7 +183,7 @@ class CalculateOrderTest extends TestCase
             )
             ->build();
 
-        $result = Util::compareWithSquareCalculation(4671, $squareResponse);
+        $result = $this->compareWithSquareCalculation(4671, $squareResponse);
 
         $this->assertTrue($result['matches']);
         $this->assertEquals(4671, $result['internal_total']);
@@ -208,7 +210,7 @@ class CalculateOrderTest extends TestCase
             )
             ->build();
 
-        $result = Util::compareWithSquareCalculation(4671, $squareResponse);
+        $result = $this->compareWithSquareCalculation(4671, $squareResponse);
 
         $this->assertFalse($result['matches']);
         $this->assertEquals(4671, $result['internal_total']);
@@ -223,7 +225,7 @@ class CalculateOrderTest extends TestCase
     {
         $squareResponse = CalculateOrderResponseBuilder::init()->build();
 
-        $result = Util::compareWithSquareCalculation(4671, $squareResponse);
+        $result = $this->compareWithSquareCalculation(4671, $squareResponse);
 
         $this->assertFalse($result['matches']);
         $this->assertNull($result['square_total']);
@@ -327,7 +329,7 @@ class CalculateOrderTest extends TestCase
         $squareResponse = Square::calculateOrder($order, env('SQUARE_LOCATION'));
 
         // Compare internal vs Square
-        $comparison = Util::compareWithSquareCalculation($internalTotal, $squareResponse);
+        $comparison = $this->compareWithSquareCalculation($internalTotal, $squareResponse);
 
         // Assert that our calculation matches Square's
         $this->assertTrue(
@@ -375,7 +377,7 @@ class CalculateOrderTest extends TestCase
 
         $internalTotal = Util::calculateTotalOrderCostByModel($order);
         $squareResponse = Square::calculateOrder($order, env('SQUARE_LOCATION'));
-        $comparison = Util::compareWithSquareCalculation($internalTotal, $squareResponse);
+        $comparison = $this->compareWithSquareCalculation($internalTotal, $squareResponse);
 
         $this->assertTrue(
             $comparison['matches'],
@@ -531,7 +533,7 @@ class CalculateOrderTest extends TestCase
 
         $internalTotal = Util::calculateTotalOrderCostByModel($order);
         $squareResponse = Square::calculateOrder($order, env('SQUARE_LOCATION'));
-        $comparison = Util::compareWithSquareCalculation($internalTotal, $squareResponse);
+        $comparison = $this->compareWithSquareCalculation($internalTotal, $squareResponse);
 
         $this->assertTrue(
             $comparison['matches'],

--- a/tests/unit/CalculateOrderTest.php
+++ b/tests/unit/CalculateOrderTest.php
@@ -366,11 +366,20 @@ class CalculateOrderTest extends TestCase
 
         $serviceCharge = factory(ServiceCharge::class)->create($serviceChargeAttrs);
 
-        $order->serviceCharges()->attach($serviceCharge->id, [
-            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
-            'featurable_type' => config('nikolag.connections.square.order.namespace'),
-            'scope'           => $scope,
-        ]);
+        if ($scope === Constants::DEDUCTIBLE_SCOPE_PRODUCT) {
+            // PRODUCT-scoped service charges must be attached to a specific line item's pivot
+            $order->products->first()->pivot->serviceCharges()->attach($serviceCharge->id, [
+                'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+                'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+                'scope'           => $scope,
+            ]);
+        } else {
+            $order->serviceCharges()->attach($serviceCharge->id, [
+                'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+                'featurable_type' => config('nikolag.connections.square.order.namespace'),
+                'scope'           => $scope,
+            ]);
+        }
 
         $order->refresh();
         $order->load('products', 'taxes', 'discounts', 'serviceCharges', 'fulfillments');

--- a/tests/unit/ServiceChargeIntegrationTest.php
+++ b/tests/unit/ServiceChargeIntegrationTest.php
@@ -105,15 +105,26 @@ class ServiceChargeIntegrationTest extends TestCase
         $this->assertCount(1, $order->products->first()->pivot->serviceCharges, 'First product should have 1 service charge');
         $this->assertEquals('Fake Percentage Fee', $order->products->first()->pivot->serviceCharges->first()->name);
 
-        // Calculate expected total:
-        // Products: (2 × $10.00) + (1 × $20.00) = $40.00
-        // Order discount: 10% of $40.00 = -$4.00, new subtotal: $36.00
-        // Product service charge: $5.00 (fixed amount on first product): $36.00 + $5.00 = $41.00
-        // Tax: 8.5% of $41.00 = $3.49, new subtotal: $44.49
-        // Order service charge: 5% of $44.49 = $2.22, new total: $46.71
+        // 0. Get the subtotal of the order before any discounts, taxes, or service charges:
+        //   (2 × $10.00) + (1 × $20.00) = $40.00
+        //   Subtotal: $40.00
+        // 1. Order-level discount applied first
+        //   Discount: -$4.00 (10% of $40.00)
+        //   Subtotal: $36.00
+        // 2. Subtotal Service charge
+        //   Service charge: +$5.00 (flat amount)
+        //   Subtotal: $41.00
+        // 3. Taxes  - calculated after order discounts and subtotal-phase service charges
+        //    Tax: $3.49 (8.5% of $41.00)
+        //    Total: $44.49
+        // 4. Total Phase Service Charge - calculated after taxes.
+        //    Service charge: $2.22 (5% of $44.49)
+        //    Total: $46.71 ($44.49 + $2.22)
         $actualTotal = Util::calculateTotalOrderCostByModel($order);
 
         $this->assertEquals(46_71, $actualTotal, 'Total calculation should include all service charges, taxes, and discounts');
+
+        $this->validateAgainstSquareApi($order, $actualTotal);
 
         // Test building Square request with service charges
         $squareBuilder = Square::getSquareBuilder();

--- a/tests/unit/ServiceChargeIntegrationTest.php
+++ b/tests/unit/ServiceChargeIntegrationTest.php
@@ -175,6 +175,8 @@ class ServiceChargeIntegrationTest extends TestCase
             $actualTotal,
             'Service charge should work correctly with variable pricing'
         );
+
+        $this->validateAgainstSquareApi($order, $actualTotal);
     }
 
     /**
@@ -213,6 +215,8 @@ class ServiceChargeIntegrationTest extends TestCase
         $actualTotal = Util::calculateTotalOrderCostByModel($order);
 
         $this->assertEquals($expectedTotal, $actualTotal);
+
+        $this->validateAgainstSquareApi($order, $actualTotal);
 
         // Test charging the order
         $transaction = $square->charge([
@@ -260,6 +264,8 @@ class ServiceChargeIntegrationTest extends TestCase
         $actualTotal = Util::calculateTotalOrderCostByModel($square->getOrder());
 
         $this->assertEquals($expectedTotal, $actualTotal);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actualTotal);
 
         // Test charging the order
         $transaction = $square->charge([
@@ -321,6 +327,8 @@ class ServiceChargeIntegrationTest extends TestCase
         $actualTotal = Util::calculateTotalOrderCostByModel($order);
 
         $this->assertEquals($expectedTotal, $actualTotal, 'Multiple service charges were not calculated correctly');
+
+        $this->validateAgainstSquareApi($order, $actualTotal);
     }
 
     /**

--- a/tests/unit/ServiceChargeIntegrationTest.php
+++ b/tests/unit/ServiceChargeIntegrationTest.php
@@ -11,6 +11,7 @@ use Nikolag\Square\Models\ServiceCharge;
 use Nikolag\Square\Models\Tax;
 use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\TestCase;
+use Nikolag\Square\Tests\Traits\AssertsSquareCalculation;
 use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
 use Square\Models\OrderServiceChargeCalculationPhase;
@@ -18,6 +19,8 @@ use Square\Models\OrderServiceChargeTreatmentType;
 
 class ServiceChargeIntegrationTest extends TestCase
 {
+    use AssertsSquareCalculation;
+
     /**
      * Test service charge integration with full order processing workflow.
      *

--- a/tests/unit/ServiceChargeIntegrationTest.php
+++ b/tests/unit/ServiceChargeIntegrationTest.php
@@ -105,24 +105,24 @@ class ServiceChargeIntegrationTest extends TestCase
         $this->assertCount(1, $order->products->first()->pivot->serviceCharges, 'First product should have 1 service charge');
         $this->assertEquals('Fake Percentage Fee', $order->products->first()->pivot->serviceCharges->first()->name);
 
-        // 0. Get the subtotal of the order before any discounts, taxes, or service charges:
-        //   (2 × $10.00) + (1 × $20.00) = $40.00
-        //   Subtotal: $40.00
-        // 1. Order-level discount applied first
-        //   Discount: -$4.00 (10% of $40.00)
-        //   Subtotal: $36.00
-        // 2. Subtotal Service charge
-        //   Service charge: +$5.00 (flat amount)
-        //   Subtotal: $41.00
-        // 3. Taxes  - calculated after order discounts and subtotal-phase service charges
-        //    Tax: $3.49 (8.5% of $41.00)
-        //    Total: $44.49
-        // 4. Total Phase Service Charge - calculated after taxes.
-        //    Service charge: $2.22 (5% of $44.49)
-        //    Total: $46.71 ($44.49 + $2.22)
+        // Per-line-item calculation (2 line items, each with ratio 0.5):
+        //
+        // Order-level totals: subtotal=$40, discount=$4.00 (10%), SC=$5+5%
+        //
+        // Each line item (apportioned by 0.5 ratio):
+        //   Base: $20.00 (line item 1: 2×$10, line item 2: 1×$20)
+        //   Discount: -$2.00 (10% of $20.00, order total: $4.00) → $18.00
+        //   Subtotal SC: +$2.50 ($5.00 × 0.5 ratio, order total: $5.00) → $20.50
+        //   Tax base: $18.00 (non-taxable SCs excluded from tax base)
+        //   Total SC: +$1.02 (5% of $20.50, bankers rounded)
+        //   Running total: $20.50 + $1.02 = $21.52
+        //   Tax: $1.53 (8.5% of $18.00)
+        //   Line item total: $21.52 + $1.53 = $23.05
+        //
+        // Order total: $23.05 × 2 = $46.10
         $actualTotal = Util::calculateTotalOrderCostByModel($order);
 
-        $this->assertEquals(46_71, $actualTotal, 'Total calculation should include all service charges, taxes, and discounts');
+        $this->assertEquals(46_10, $actualTotal, 'Total calculation should include all service charges, taxes, and discounts');
 
         $this->validateAgainstSquareApi($order, $actualTotal);
 
@@ -177,8 +177,8 @@ class ServiceChargeIntegrationTest extends TestCase
 
         $order->refresh();
 
-        // Expected: 3 × $15.00 = $45.00, service charge 2.5% = $1.13, total = $46.13 = 4613 cents
-        $expectedTotal = 4613;
+        // Expected: 3 × $15.00 = $45.00, service charge 2.5% = $1.125 → $1.12 (bankers rounding), total = $46.12
+        $expectedTotal = 4612;
         $actualTotal = Util::calculateTotalOrderCostByModel($order);
 
         $this->assertEquals(

--- a/tests/unit/ServiceChargeIntegrationTest.php
+++ b/tests/unit/ServiceChargeIntegrationTest.php
@@ -30,8 +30,8 @@ class ServiceChargeIntegrationTest extends TestCase
     {
         // Create test data
         $order = factory(Order::class)->create();
-        $product1 = factory(ModelsProduct::class)->create(['price' => 1000]); // $10.00
-        $product2 = factory(Product::class)->create(['price' => 2000]); // $20.00
+        $product1 = factory(ModelsProduct::class)->create(['price' => 10_00]); // $10.00
+        $product2 = factory(Product::class)->create(['price' => 20_00]); // $20.00
 
         // Create service charges
         $orderServiceCharge = factory(ServiceCharge::class)->create([

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -485,8 +485,8 @@ class UtilTest extends TestCase
 
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
-        // Base: 1000, Discount 10%: -100 = 900, Tax 10%: +90 = 990, Service charge 5%: +49.5 = 1039.5 (rounded to 1040)
-        $this->assertEquals(1040, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        // Base: 1000, Discount 10%: -100 = 900, Service charge 5%: +45 = 945, Tax 10%: +94.5 -> bankers rounds to 94, Total: 1039
+        $this->assertEquals(1039, Util::calculateTotalOrderCostByModel($square->getOrder()));
     }
 
     /**
@@ -856,5 +856,499 @@ class UtilTest extends TestCase
             'Tax calculation phases did not produce expected result. '.
             'Expected: $115.83, Actual: $'.number_format($actualTotal / 100, 2)
         );
+    }
+
+    // ========================================================================
+    // calculateLineItemTotalByModel tests
+    // ========================================================================
+
+    /**
+     * Helper: create a simple order with a product-based line item.
+     *
+     * @param int $price    Base price in cents.
+     * @param int $quantity Quantity of items.
+     *
+     * @return array{order: Order, lineItem: \Nikolag\Square\Models\OrderProductPivot}
+     */
+    private function createOrderWithLineItem(int $price = 10_00, int $quantity = 1): array
+    {
+        $this->data->order->save();
+        $product = factory(Product::class)->create(['price' => $price]);
+        $this->data->order->attachProduct($product, ['quantity' => $quantity]);
+
+        $order = $this->data->order->fresh();
+        $order->load('lineItems');
+        $lineItem = $order->lineItems->first();
+
+        return ['order' => $order, 'lineItem' => $lineItem];
+    }
+
+    /**
+     * Test line item total with no deductibles equals gross sales.
+     */
+    public function test_line_item_total_no_deductibles(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 3);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem, $order);
+
+        // 10.00 × 3 = 30.00
+        $this->assertEquals(30_00, $total);
+    }
+
+    /**
+     * Test line item total with a LINE_ITEM-scoped percentage discount.
+     */
+    public function test_line_item_total_with_line_item_percentage_discount(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 2);
+
+        $discount = factory(Discount::class)->create([
+            'percentage' => 10.0,
+            'amount'     => null,
+        ]);
+
+        $lineItem->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // Base: 10.00 × 2 = 20.00, Discount 10%: -2.00 = 18.00
+        $this->assertEquals(18_00, $total);
+    }
+
+    /**
+     * Test line item total with a LINE_ITEM-scoped fixed-amount discount.
+     */
+    public function test_line_item_total_with_line_item_fixed_discount(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 2);
+
+        $discount = factory(Discount::class)->create([
+            'amount'     => 3_00,
+            'percentage' => null,
+        ]);
+
+        $lineItem->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // Base: 10.00 × 2 = 20.00, Discount $3.00: 17.00
+        $this->assertEquals(17_00, $total);
+    }
+
+    /**
+     * Test line item total with an ORDER-scoped percentage discount.
+     */
+    public function test_line_item_total_with_order_percentage_discount(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 2);
+
+        $discount = factory(Discount::class)->create([
+            'percentage' => 20.0,
+            'amount'     => null,
+        ]);
+
+        $order->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // Base: 10.00 × 2 = 20.00, ORDER discount 20%: -4.00 = 16.00
+        $this->assertEquals(16_00, $total);
+    }
+
+    /**
+     * Test line item total with an ORDER-scoped fixed-amount discount apportioned across 2 line items.
+     */
+    public function test_line_item_total_with_order_fixed_discount_apportioned(): void
+    {
+        $this->data->order->save();
+
+        $product1 = factory(Product::class)->create(['price' => 30_00]);
+        $product2 = factory(Product::class)->create(['price' => 70_00]);
+
+        $this->data->order->attachProduct($product1, ['quantity' => 1]); // $30.00
+        $this->data->order->attachProduct($product2, ['quantity' => 1]); // $70.00
+
+        $discount = factory(Discount::class)->create([
+            'amount'     => 10_00, // $10 order discount
+            'percentage' => null,
+        ]);
+
+        $this->data->order->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $order = $this->data->order->fresh();
+        $order->load('lineItems');
+
+        $lineItem1 = $order->lineItems->where('product_id', $product1->id)->first();
+        $lineItem2 = $order->lineItems->where('product_id', $product2->id)->first();
+
+        $total1 = Util::calculateLineItemTotalByModel($lineItem1, $order);
+        $total2 = Util::calculateLineItemTotalByModel($lineItem2, $order);
+
+        // $30/$100 × $10 = $3.00 apportioned → $30 - $3 = $27.00
+        $this->assertEquals(27_00, $total1);
+        // $70/$100 × $10 = $7.00 apportioned → $70 - $7 = $63.00
+        $this->assertEquals(63_00, $total2);
+        // Sum should equal order total minus discount
+        $this->assertEquals(90_00, $total1 + $total2);
+    }
+
+    /**
+     * Test line item discounts follow Square's documented calculation order.
+     */
+    public function test_line_item_total_with_stacked_discounts_uses_square_sequence(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(100_00, 1);
+
+        $itemPercentageDiscount = factory(Discount::class)->create([
+            'percentage' => 10.0,
+            'amount'     => null,
+        ]);
+        $orderPercentageDiscount = factory(Discount::class)->create([
+            'percentage' => 20.0,
+            'amount'     => null,
+        ]);
+        $itemFixedDiscount = factory(Discount::class)->create([
+            'amount'     => 3_00,
+            'percentage' => null,
+        ]);
+        $orderFixedDiscount = factory(Discount::class)->create([
+            'amount'     => 5_00,
+            'percentage' => null,
+        ]);
+
+        $lineItem->discounts()->attach($itemPercentageDiscount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
+        ]);
+        $lineItem->discounts()->attach($itemFixedDiscount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
+        ]);
+        $order->discounts()->attach($orderPercentageDiscount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+        $order->discounts()->attach($orderFixedDiscount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // $100.00 -> item 10% = $90.00 -> order 20% = $72.00 -> item $3 = $69.00 -> order $5 = $64.00
+        $this->assertEquals(64_00, $total);
+    }
+
+    /**
+     * Test line item total with an additive tax.
+     */
+    public function test_line_item_total_with_additive_tax(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 1);
+
+        $tax = factory(Tax::class)->create([
+            'percentage' => 10.0,
+            'type'       => Constants::TAX_ADDITIVE,
+        ]);
+
+        $lineItem->taxes()->attach($tax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // Base: $10.00, Tax 10%: +$1.00 = $11.00
+        $this->assertEquals(11_00, $total);
+    }
+
+    /**
+     * Test line item total with an inclusive tax (should not increase total).
+     */
+    public function test_line_item_total_with_inclusive_tax(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(11_00, 1);
+
+        $tax = factory(Tax::class)->create([
+            'percentage' => 10.0,
+            'type'       => Constants::TAX_INCLUSIVE,
+        ]);
+
+        $lineItem->taxes()->attach($tax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // Inclusive tax is already embedded in the price — total should not change
+        $this->assertEquals(11_00, $total);
+    }
+
+    /**
+     * Test line item total with ORDER-scoped additive tax.
+     */
+    public function test_line_item_total_with_order_additive_tax(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 1);
+
+        $tax = factory(Tax::class)->create([
+            'percentage' => 8.5,
+            'type'       => Constants::TAX_ADDITIVE,
+        ]);
+
+        $order->taxes()->attach($tax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // Base: $10.00, ORDER tax 8.5%: +$0.85 = $10.85
+        $this->assertEquals(10_85, $total);
+    }
+
+    /**
+     * Test that sum of per-line-item totals equals calculateTotalOrderCostByModel
+     * for a multi-line-item order with ORDER-scoped discount and tax.
+     */
+    public function test_line_item_totals_sum_matches_order_total(): void
+    {
+        $this->data->order->save();
+
+        $product1 = factory(Product::class)->create(['price' => 15_00]);
+        $product2 = factory(Product::class)->create(['price' => 50_00]);
+        $product3 = factory(Product::class)->create(['price' => 12_00]);
+
+        $this->data->order->attachProduct($product1, ['quantity' => 2]); // $30.00
+        $this->data->order->attachProduct($product2, ['quantity' => 1]); // $50.00
+        $this->data->order->attachProduct($product3, ['quantity' => 3]); // $36.00
+
+        // Order-level percentage discount
+        $discount = factory(Discount::class)->create([
+            'percentage' => 10.0,
+            'amount'     => null,
+        ]);
+        $this->data->order->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        // Order-level additive tax
+        $tax = factory(Tax::class)->create([
+            'percentage' => 8.5,
+            'type'       => Constants::TAX_ADDITIVE,
+        ]);
+        $this->data->order->taxes()->attach($tax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
+        $order = $square->getOrder();
+        $order->load('lineItems');
+
+        $orderTotal = Util::calculateTotalOrderCostByModel($order);
+
+        $lineItemSum = $order->lineItems->sum(
+            fn ($li) => Util::calculateLineItemTotalByModel($li, $order)
+        );
+
+        $this->assertSame(
+            $orderTotal,
+            $lineItemSum,
+            "Line item sum ($lineItemSum) should exactly match order total ($orderTotal)"
+        );
+    }
+
+    /**
+     * Test apportioned percentage service charge on a line item.
+     */
+    public function test_line_item_total_with_apportioned_percentage_service_charge(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 2);
+
+        $serviceCharge = factory(ServiceCharge::class)->create([
+            'percentage'        => 10.0,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_PERCENTAGE_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ]);
+
+        $order->serviceCharges()->attach($serviceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // Base: $20.00, Service charge 10%: +$2.00 = $22.00
+        $this->assertEquals(22_00, $total);
+    }
+
+    /**
+     * Test apportioned fixed-amount service charge is distributed by gross sales ratio.
+     */
+    public function test_line_item_total_with_apportioned_amount_service_charge(): void
+    {
+        $this->data->order->save();
+
+        $product1 = factory(Product::class)->create(['price' => 30_00]);
+        $product2 = factory(Product::class)->create(['price' => 70_00]);
+
+        $this->data->order->attachProduct($product1, ['quantity' => 1]);
+        $this->data->order->attachProduct($product2, ['quantity' => 1]);
+
+        $serviceCharge = factory(ServiceCharge::class)->create([
+            'amount_money'      => 10_00,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_AMOUNT_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
+            'taxable'           => false,
+        ]);
+
+        $this->data->order->serviceCharges()->attach($serviceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+
+        $order = $this->data->order->fresh();
+        $order->load('lineItems');
+
+        $lineItem1 = $order->lineItems->where('product_id', $product1->id)->first();
+        $lineItem2 = $order->lineItems->where('product_id', $product2->id)->first();
+
+        $total1 = Util::calculateLineItemTotalByModel($lineItem1, $order);
+        $total2 = Util::calculateLineItemTotalByModel($lineItem2, $order);
+
+        // $10 order service charge apportioned over $30/$70 gross sales.
+        $this->assertEquals(33_00, $total1);
+        $this->assertEquals(77_00, $total2);
+        $this->assertEquals(110_00, $total1 + $total2);
+    }
+
+    /**
+     * Test service charge taxes are calculated from the discounted service charge amount.
+     */
+    public function test_line_item_total_with_taxable_percentage_service_charge_after_discount(): void
+    {
+        ['order' => $order, 'lineItem' => $lineItem] = $this->createOrderWithLineItem(10_00, 1);
+
+        $discount = factory(Discount::class)->create([
+            'percentage' => 10.0,
+            'amount'     => null,
+        ]);
+        $serviceChargeTax = factory(Tax::class)->create([
+            'percentage' => 8.0,
+            'type'       => Constants::TAX_ADDITIVE,
+        ]);
+        $serviceCharge = factory(ServiceCharge::class)->create([
+            'percentage'        => 5.0,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE,
+            'treatment_type'    => OrderServiceChargeTreatmentType::LINE_ITEM_TREATMENT,
+            'taxable'           => true,
+        ]);
+
+        $order->discounts()->attach($discount->id, [
+            'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+        $order->serviceCharges()->attach($serviceCharge->id, [
+            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'featurable_type' => config('nikolag.connections.square.order.namespace'),
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+        ]);
+        $serviceCharge->taxes()->attach($serviceChargeTax->id, [
+            'deductible_type' => Constants::TAX_NAMESPACE,
+            'featurable_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+            'scope'           => Constants::DEDUCTIBLE_SCOPE_SERVICE_CHARGE,
+        ]);
+
+        $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+        // $10.00 -> 10% discount = $9.00 -> 5% service charge = $0.45 -> 8% tax on service charge = $0.04
+        $this->assertEquals(9_49, $total);
+    }
+
+    /**
+     * Test banker rounding is used for .5 cent adjustments.
+     */
+    public function test_line_item_total_uses_bankers_rounding_for_percentage_adjustments(): void
+    {
+        $scenarios = [
+            [
+                'price'            => 5_00,
+                'percentage'       => 10.1,
+                'expectedTotal'    => 4_50,
+                'expectedDiscount' => '0.505 -> 0.50',
+            ],
+            [
+                'price'            => 11_00,
+                'percentage'       => 6.5,
+                'expectedTotal'    => 10_28,
+                'expectedDiscount' => '0.715 -> 0.72',
+            ],
+            [
+                'price'            => 1_00,
+                'percentage'       => 8.5,
+                'expectedTotal'    => 92,
+                'expectedDiscount' => '0.085 -> 0.08',
+            ],
+        ];
+
+        foreach ($scenarios as $scenario) {
+            $order = factory(Order::class)->create();
+            $product = factory(Product::class)->create(['price' => $scenario['price']]);
+            $order->attachProduct($product, ['quantity' => 1]);
+            $order->load('lineItems');
+            $lineItem = $order->lineItems->first();
+
+            $discount = factory(Discount::class)->create([
+                'percentage' => $scenario['percentage'],
+                'amount'     => null,
+            ]);
+
+            $order->discounts()->attach($discount->id, [
+                'deductible_type' => Constants::DISCOUNT_NAMESPACE,
+                'featurable_type' => config('nikolag.connections.square.order.namespace'),
+                'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
+            ]);
+
+            $total = Util::calculateLineItemTotalByModel($lineItem->fresh(), $order->fresh());
+
+            $this->assertEquals(
+                $scenario['expectedTotal'],
+                $total,
+                "Expected documented bankers rounding example {$scenario['expectedDiscount']} to be preserved."
+            );
+        }
     }
 }

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -772,6 +772,8 @@ class UtilTest extends TestCase
         $actualTotal = Util::calculateTotalOrderCostByModel($square->getOrder());
 
         $this->assertEquals($expectedTotal, $actualTotal);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actualTotal);
     }
 
     /**
@@ -810,6 +812,8 @@ class UtilTest extends TestCase
         $actualTotal = Util::calculateTotalOrderCostByModel($square->getOrder());
 
         $this->assertEquals($expectedTotal, $actualTotal);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actualTotal);
     }
 
     /**
@@ -934,6 +938,8 @@ class UtilTest extends TestCase
 
         // 10.00 × 3 = 30.00
         $this->assertEquals(30_00, $total);
+
+        $this->validateAgainstSquareApi($order, $total);
     }
 
     /**
@@ -958,6 +964,9 @@ class UtilTest extends TestCase
 
         // Base: 10.00 × 2 = 20.00, Discount 10%: -2.00 = 18.00
         $this->assertEquals(18_00, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -982,6 +991,9 @@ class UtilTest extends TestCase
 
         // Base: 10.00 × 2 = 20.00, Discount $3.00: 17.00
         $this->assertEquals(17_00, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1006,6 +1018,9 @@ class UtilTest extends TestCase
 
         // Base: 10.00 × 2 = 20.00, ORDER discount 20%: -4.00 = 16.00
         $this->assertEquals(16_00, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1047,6 +1062,8 @@ class UtilTest extends TestCase
         $this->assertEquals(63_00, $total2);
         // Sum should equal order total minus discount
         $this->assertEquals(90_00, $total1 + $total2);
+
+        $this->validateAgainstSquareApi($order, $total1 + $total2);
     }
 
     /**
@@ -1098,6 +1115,9 @@ class UtilTest extends TestCase
 
         // $100.00 -> item 10% = $90.00 -> order 20% = $72.00 -> item $3 = $69.00 -> order $5 = $64.00
         $this->assertEquals(64_00, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1122,6 +1142,9 @@ class UtilTest extends TestCase
 
         // Base: $10.00, Tax 10%: +$1.00 = $11.00
         $this->assertEquals(11_00, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1146,6 +1169,9 @@ class UtilTest extends TestCase
 
         // Inclusive tax is already embedded in the price — total should not change
         $this->assertEquals(11_00, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1170,6 +1196,9 @@ class UtilTest extends TestCase
 
         // Base: $10.00, ORDER tax 8.5%: +$0.85 = $10.85
         $this->assertEquals(10_85, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1225,6 +1254,8 @@ class UtilTest extends TestCase
             $lineItemSum,
             "Line item sum ($lineItemSum) should exactly match order total ($orderTotal)"
         );
+
+        $this->validateAgainstSquareApi($order, $orderTotal);
     }
 
     /**
@@ -1251,6 +1282,9 @@ class UtilTest extends TestCase
 
         // Base: $20.00, Service charge 10%: +$2.00 = $22.00
         $this->assertEquals(22_00, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1292,6 +1326,8 @@ class UtilTest extends TestCase
         $this->assertEquals(33_00, $total1);
         $this->assertEquals(77_00, $total2);
         $this->assertEquals(110_00, $total1 + $total2);
+
+        $this->validateAgainstSquareApi($order, $total1 + $total2);
     }
 
     /**
@@ -1336,6 +1372,9 @@ class UtilTest extends TestCase
 
         // $10.00 -> 10% discount = $9.00 -> 5% service charge = $0.45 -> 8% tax on service charge = $0.04
         $this->assertEquals(9_49, $total);
+
+        $freshOrder = $order->fresh();
+        $this->validateAgainstSquareApi($freshOrder, $total);
     }
 
     /**
@@ -1389,6 +1428,9 @@ class UtilTest extends TestCase
                 $total,
                 "Expected documented bankers rounding example {$scenario['expectedDiscount']} to be preserved."
             );
+
+            $freshOrder = $order->fresh();
+            $this->validateAgainstSquareApi($freshOrder, $total);
         }
     }
 }

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -684,7 +684,7 @@ class UtilTest extends TestCase
     {
         $serviceCharge = factory(ServiceCharge::class)->create([
             'percentage'        => 15.0,
-            'calculation_phase' => OrderServiceChargeCalculationPhase::TOTAL_PHASE,
+            'calculation_phase' => OrderServiceChargeCalculationPhase::APPORTIONED_PERCENTAGE_PHASE,
             'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
             'taxable'           => false,
         ]);
@@ -707,7 +707,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
         // Base cost: 1000, Product service charge 15%: 150, Total: 1150
-        $this->assertEquals(1150, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(1150, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -821,9 +824,9 @@ class UtilTest extends TestCase
      *
      * @return void
      */
-    public function test_comprehensive_tax_calculation_phases(): void
+    public function test_dual_tax_phases_calculation(): void
     {
-        // Create both subtotal and total phase taxes
+        // Create both subtotal and total phase taxes (no service charges)
         $subtotalTax = factory(Tax::class)->create([
             'name'              => 'State Tax (Subtotal)',
             'percentage'        => 5.0,
@@ -838,27 +841,10 @@ class UtilTest extends TestCase
             'calculation_phase' => TaxCalculationPhase::TAX_TOTAL_PHASE,
         ]);
 
-        // Create service charges for both phases
-        $subtotalServiceCharge = factory(ServiceCharge::class)->create([
-            'name'              => 'Processing Fee',
-            'amount_money'      => 5_00, // $5.00
-            'calculation_phase' => OrderServiceChargeCalculationPhase::SUBTOTAL_PHASE,
-            'taxable'           => false,
-        ]);
-
-        $totalServiceCharge = factory(ServiceCharge::class)->create([
-            'name'              => 'Convenience Fee',
-            'percentage'        => 2.0,
-            'calculation_phase' => OrderServiceChargeCalculationPhase::TOTAL_PHASE,
-            'treatment_type'    => OrderServiceChargeTreatmentType::APPORTIONED_TREATMENT,
-            'taxable'           => false,
-        ]);
-
         $this->data->order->save();
         $this->data->product->price = 100_00; // $100.00
         $this->data->product->save();
 
-        // Attach both taxes
         $this->data->order->taxes()->attach($subtotalTax->id, [
             'deductible_type' => Constants::TAX_NAMESPACE,
             'featurable_type' => config('nikolag.connections.square.order.namespace'),
@@ -870,36 +856,14 @@ class UtilTest extends TestCase
             'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
         ]);
 
-        // Attach both service charges
-        $this->data->order->serviceCharges()->attach($subtotalServiceCharge->id, [
-            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
-            'featurable_type' => config('nikolag.connections.square.order.namespace'),
-            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
-        ]);
-        $this->data->order->serviceCharges()->attach($totalServiceCharge->id, [
-            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
-            'featurable_type' => config('nikolag.connections.square.order.namespace'),
-            'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
-        ]);
-
         $this->data->order->attachProduct($this->data->product);
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
-        // Expected calculation:
-        // Step 1: Base amount = $100.00
-        // Step 2: Subtotal service charge = $5.00 → Subtotal = $105.00
-        // Step 3: Subtotal tax (5%) = $5.25 → After subtotal tax = $110.25
-        // Step 4: Total service charge (2%) = $2.21 → Before total tax = $112.46
-        // Step 5: Total tax (3%) = $3.37 → Final total = $115.83
-        $expectedTotal = 115_83;
+        // Expected: Base $100.00 + subtotal tax 5% ($5.00) + total-phase tax 3% ($3.00) = $108.00
         $actualTotal = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(108_00, $actualTotal);
 
-        $this->assertEquals(
-            $expectedTotal,
-            $actualTotal,
-            'Tax calculation phases did not produce expected result. '.
-            'Expected: $115.83, Actual: $'.number_format($actualTotal / 100, 2)
-        );
+        $this->validateAgainstSquareApi($square->getOrder(), $actualTotal);
     }
 
     // ========================================================================

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -548,17 +548,20 @@ class UtilTest extends TestCase
             'scope'           => Constants::DEDUCTIBLE_SCOPE_ORDER,
         ]);
 
-        // Add the service charge to the order
-        $this->data->order->serviceCharges()->attach($serviceCharge->id, [
-            'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
-            'featurable_type' => config('nikolag.connections.square.order.namespace'),
-            'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
-        ]);
-
+        // Attach the service charge to each product's pivot (PRODUCT scope = per line item)
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
+        $order = $square->getOrder();
 
-        // Base cost: $116.00, Service charge $10.00 x 6 = $60.00, Total: $176.00
-        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        foreach ($order->products as $product) {
+            $product->pivot->serviceCharges()->attach($serviceCharge->id, [
+                'deductible_type' => Constants::SERVICE_CHARGE_NAMESPACE,
+                'featurable_type' => Constants::ORDER_PRODUCT_NAMESPACE,
+                'scope'           => Constants::DEDUCTIBLE_SCOPE_PRODUCT,
+            ]);
+        }
+
+        // Base cost: $116.00, Service charge $10.00 x 6 (total qty) = $60.00, Total: $176.00
+        $actual = Util::calculateTotalOrderCostByModel($order->fresh());
         $this->assertEquals(176_00, $actual);
 
         $this->validateAgainstSquareApi($square->getOrder(), $actual);

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -105,6 +105,8 @@ class UtilTest extends TestCase
         $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
 
         $this->assertEquals($expected, $actual, 'Util::calculateTotalOrderCost didn\'t calculate properly.');
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -129,7 +131,10 @@ class UtilTest extends TestCase
             ->save();
 
         // The expected total is 935.
-        $this->assertEquals(935, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(935, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -158,7 +163,10 @@ class UtilTest extends TestCase
             ->save();
 
         // The expected total is $27.50.
-        $this->assertEquals(2750, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(2750, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -182,7 +190,10 @@ class UtilTest extends TestCase
             ->save();
 
         // The expected total is 990.
-        $this->assertEquals(990, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(990, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -244,7 +255,10 @@ class UtilTest extends TestCase
             ->save();
 
         // Expected total is 3 * 750 = 2250
-        $this->assertEquals(2250, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(2250, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -276,7 +290,10 @@ class UtilTest extends TestCase
             ->save();
 
         // The expected total is $32.50.
-        $this->assertEquals(32_50, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(32_50, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -406,7 +423,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
         // Base cost: $116.00, Service charge $10.00, Total: $126.00
-        $this->assertEquals(126_00, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(126_00, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -437,7 +457,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
         // Base cost: $116.00, Service charge $11.60, Total: $127.60
-        $this->assertEquals(127_60, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(127_60, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -488,7 +511,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
         // Base: 1000, Discount 10%: -100 = 900, Service charge 5%: +45 = 945, Tax 10%: +94.5 -> bankers rounds to 94, Total: 1039
-        $this->assertEquals(1039, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(1039, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -532,7 +558,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
         // Base cost: $116.00, Service charge $10.00 x 6 = $60.00, Total: $176.00
-        $this->assertEquals(176_00, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(176_00, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -575,7 +604,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order->refresh(), env('SQUARE_LOCATION'))->save();
 
         // Base cost: $116.00, Service charge $10.00, Tax on service charge $0.80 Total: $126.80
-        $this->assertEquals(126_80, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(126_80, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -602,7 +634,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
         // Base cost: $116.00, Service charge $1.74, Total: $117.74
-        $this->assertEquals(117_74, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(117_74, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**
@@ -634,7 +669,10 @@ class UtilTest extends TestCase
         $square = Square::setOrder($this->data->order, env('SQUARE_LOCATION'))->save();
 
         // Base cost: 1000, Service charge fixed: 200, Total: 1200
-        $this->assertEquals(1200, Util::calculateTotalOrderCostByModel($square->getOrder()));
+        $actual = Util::calculateTotalOrderCostByModel($square->getOrder());
+        $this->assertEquals(1200, $actual);
+
+        $this->validateAgainstSquareApi($square->getOrder(), $actual);
     }
 
     /**

--- a/tests/unit/UtilTest.php
+++ b/tests/unit/UtilTest.php
@@ -15,6 +15,7 @@ use Nikolag\Square\Tests\Models\Order;
 use Nikolag\Square\Tests\Models\User;
 use Nikolag\Square\Tests\TestCase;
 use Nikolag\Square\Tests\TestDataHolder;
+use Nikolag\Square\Tests\Traits\AssertsSquareCalculation;
 use Nikolag\Square\Utils\Constants;
 use Nikolag\Square\Utils\Util;
 use Square\Models\OrderServiceChargeCalculationPhase;
@@ -23,6 +24,7 @@ use Square\Models\TaxCalculationPhase;
 
 class UtilTest extends TestCase
 {
+    use AssertsSquareCalculation;
     /**
      * @var Order
      */


### PR DESCRIPTION
## Summary

   Adds per-line-item order total calculation and fixes several bugs in how service charges and taxes interact. This decouples pricing from the
   product model so line items can carry their own base price, and introduces Square's CalculateOrder API for validation.

   ### Per-line-item calculation engine
   - New `calculateLineItemTotalByModel()` in `Util` calculates each line item independently when an order has multiple products — apportioning
   order-level discounts, taxes, and service charges by gross-sales ratio.
   - Adds `lineItems()` HasMany relationship to orders for direct access to `OrderProductPivot` rows (including custom line items without a linked
   product).

   ### Service charge fixes
   - **Non-taxable SCs excluded from tax base**: service charges with `taxable=false` were incorrectly inflating the amount that taxes were calculated
    on. Both the single-item (`_calculateTotalCost`) and multi-item (`_calculateLineItemTotal`) paths now separate taxable vs non-taxable SC amounts
   when building the tax base.
   - **PRODUCT-scoped SCs no longer leak to all line items**: the order-wide collection from `collectServiceCharges()` was merged into every line
   item's deductibles, applying a product-specific charge to unrelated line items. Removed that merge — `$lineItemServiceCharges` (from the pivot)
   already captures per-line-item SCs correctly.
   - **Duplicate applied-service-charge UIDs**: `buildProducts()` applied SCs to each line item, then `buildSquareOrder()` re-applied all
   PRODUCT-scoped SCs to every line item. Removed the redundant second pass.
   - **SUBTOTAL_PHASE validation in multi-item path**: the existing guard in `_calculateProductServiceCharges` (single-item path) now also exists in
   `_calculateLineItemServiceChargeAmount` so orders with multiple products correctly reject SUBTOTAL_PHASE charges on PRODUCT scope.

   ### CalculateOrder API integration
   - New `calculateOrder()` on `SquareService` and `SquareServiceContract` calls Square's read-only CalculateOrder endpoint.
   - `buildCalculateOrderRequest()` and shared `buildSquareOrder()` extracted in `SquareRequestBuilder` to DRY up order building across create,
   update, and calculate flows.
   - `AssertsSquareCalculation` trait with `validateAgainstSquareApi()` helper — gated behind `SQUARE_VALIDATE_CALCULATIONS` env flag so tests are
   fast by default and hit Square only when opted in.
   - `CalculateOrderTest` covers request building, mocked success/error, comparison helpers, and live validation of service charge combinations
   against Square's API.

   ### Other calculation improvements
   - Bankers rounding (`PHP_ROUND_HALF_EVEN`) applied consistently to discount and service charge calculations.
   - Service charge taxes built into the Square request (applied-tax references on SCs, merged into order-level taxes).